### PR TITLE
Fix TypeError when hiding/disposing uninitialized Modal or Offcanvas

### DIFF
--- a/src/Money.Blazor.Host/wwwroot/js/site.js
+++ b/src/Money.Blazor.Host/wwwroot/js/site.js
@@ -25,13 +25,19 @@ window.Bootstrap = {
             $container.data("modal").show();
         },
         Hide: function (container) {
-            $(container).data("modal").hide();
+            var modal = $(container).data("modal");
+            if (modal) {
+                modal.hide();
+            }
         },
         IsOpen: function (container) {
             return $(container).hasClass("show");
         },
         Dispose: function (container) {
-            $(container).data("modal").dispose();
+            var modal = $(container).data("modal");
+            if (modal) {
+                modal.dispose();
+            }
         }
     },
     Offcanvas: {
@@ -48,13 +54,22 @@ window.Bootstrap = {
             }
         },
         Show: function (container) {
-            bootstrap.Offcanvas.getInstance(container).show()
+            var offcanvas = bootstrap.Offcanvas.getInstance(container);
+            if (offcanvas) {
+                offcanvas.show();
+            }
         },
         Hide: function (container) {
-            bootstrap.Offcanvas.getInstance(container).hide();
+            var offcanvas = bootstrap.Offcanvas.getInstance(container);
+            if (offcanvas) {
+                offcanvas.hide();
+            }
         },
         Dispose: function (container) {
-            bootstrap.Offcanvas.getInstance(container).dispose();
+            var offcanvas = bootstrap.Offcanvas.getInstance(container);
+            if (offcanvas) {
+                offcanvas.dispose();
+            }
         }
     },
     Theme: {


### PR DESCRIPTION
## Problem

Fixes #601

`Bootstrap.Modal.Hide()` in `site.js` throws `TypeError: Cannot read properties of undefined (reading 'hide')` when called on a modal that was never shown. This happens because `Modal.Dispose()` in the Blazor component unconditionally calls `Hide()`, which invokes the JS function — but `$(container).data("modal")` is `undefined` if `Show()` was never called.

## Fix

Added null guards to all Bootstrap interop methods in `site.js` that access instances which may not exist:

- **Modal.Hide / Modal.Dispose**: check `$(container).data("modal")` before calling methods
- **Offcanvas.Show / Hide / Dispose**: check `bootstrap.Offcanvas.getInstance(container)` before calling methods

All methods now silently no-op when the instance doesn't exist.