### PR TITLE
Add Aspire AppHost for local development

### DIFF
--- a/src/AppHost.cs
+++ b/src/AppHost.cs
@@ -1,0 +1,37 @@
+#:sdk Aspire.AppHost.Sdk@13.2.3
+#:project .\Money.Api\Money.Api.csproj
+#:project .\Money.Blazor.Host\Money.Blazor.Host.csproj
+
+var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions 
+{
+    DashboardApplicationName = "Money AppHost",
+    Args = args,
+});
+
+var api = builder
+    .AddProject<Projects.Money_Api>("api");
+
+// var isWatch = builder.Configuration.GetValue<string>("DOTNET_WATCH") == "1";
+var isWatch = true;
+if (isWatch)
+{
+    var uiProjectDirectory = Path.GetDirectoryName(new Projects.Money_Blazor_Host().ProjectPath)!;
+
+    builder
+        .AddExecutable("ui", "dotnet", uiProjectDirectory, ["watch", "--non-interactive", "--verbose"])
+        .WithEnvironment(context =>
+        {
+            context.EnvironmentVariables["DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER"] = "1";
+            context.EnvironmentVariables["DOTNET_WATCH_RESTART_ON_RUDE_EDIT"] = "1";
+        })
+        .WithHttpEndpoint(targetPort: 48613, isProxied: false)
+        .WithReference(api);
+}
+else
+{
+    builder
+        .AddProject<Projects.Money_Blazor_Host>("ui")
+        .WithReference(api);
+}
+
+builder.Build().Run();

--- a/src/AppHost.cs
+++ b/src/AppHost.cs
@@ -11,27 +11,8 @@ var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOpt
 var api = builder
     .AddProject<Projects.Money_Api>("api");
 
-// var isWatch = builder.Configuration.GetValue<string>("DOTNET_WATCH") == "1";
-var isWatch = true;
-if (isWatch)
-{
-    var uiProjectDirectory = Path.GetDirectoryName(new Projects.Money_Blazor_Host().ProjectPath)!;
-
-    builder
-        .AddExecutable("ui", "dotnet", uiProjectDirectory, ["watch", "--non-interactive", "--verbose"])
-        .WithEnvironment(context =>
-        {
-            context.EnvironmentVariables["DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER"] = "1";
-            context.EnvironmentVariables["DOTNET_WATCH_RESTART_ON_RUDE_EDIT"] = "1";
-        })
-        .WithHttpEndpoint(targetPort: 48613, isProxied: false)
-        .WithReference(api);
-}
-else
-{
-    builder
-        .AddProject<Projects.Money_Blazor_Host>("ui")
-        .WithReference(api);
-}
+builder
+    .AddProject<Projects.Money_Blazor_Host>("ui")
+    .WithReference(api);
 
 builder.Build().Run();

--- a/src/AppHost.cs
+++ b/src/AppHost.cs
@@ -1,4 +1,4 @@
-#:sdk Aspire.AppHost.Sdk@13.2.3
+#:sdk Aspire.AppHost.Sdk@13.2.4
 #:project .\Money.Api\Money.Api.csproj
 #:project .\Money.Blazor.Host\Money.Blazor.Host.csproj
 

--- a/src/AppHost.cs
+++ b/src/AppHost.cs
@@ -1,6 +1,6 @@
 #:sdk Aspire.AppHost.Sdk@13.2.4
-#:project .\Money.Api\Money.Api.csproj
-#:project .\Money.Blazor.Host\Money.Blazor.Host.csproj
+#:project ./Money.Api/Money.Api.csproj
+#:project ./Money.Blazor.Host/Money.Blazor.Host.csproj
 
 var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions 
 {

--- a/src/AppHost.run.json
+++ b/src/AppHost.run.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:17229",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19035",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20053",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS": "true"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17230;http://localhost:17229",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21149",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22221"
+      }
+    }
+  }
+}

--- a/src/Money.Api/Properties/launchSettings.json
+++ b/src/Money.Api/Properties/launchSettings.json
@@ -1,20 +1,5 @@
-﻿{
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:63803/",
-      "sslPort": 0
-    }
-  },
+{
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": false,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "dotnet run": {
       "commandName": "Project",
       "launchBrowser": false,


### PR DESCRIPTION
Adds a file-based Aspire AppHost to orchestrate the API and Blazor UI projects during local development, providing a unified dashboard for managing and monitoring both services.

## Changes

- **`src/AppHost.cs`** -- File-based Aspire AppHost (using `Aspire.AppHost.Sdk@13.2.4`) that registers `Money.Api` and `Money.Blazor.Host` as managed projects with a service reference from UI to API.
- **`src/AppHost.run.json`** -- Launch settings for the AppHost with `http` and `https` profiles for the Aspire dashboard.
- **`src/Money.Api/Properties/launchSettings.json`** -- Removed legacy `iisSettings` and `IIS Express` profile, keeping only the `dotnet run` profile.

## Usage

```
cd src
dotnet run AppHost.cs
```