### PR TITLE
Fix currency reset to default when changing amount

### DIFF
--- a/src/Money.Blazor.Host/Components/AmountBox.razor.cs
+++ b/src/Money.Blazor.Host/Components/AmountBox.razor.cs
@@ -46,7 +46,9 @@ public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries)
         {
             DecimalDigits = await Queries.QueryAsync(new GetPriceDecimalDigitsProperty());
             Currencies = await Queries.QueryAsync(new ListAllCurrency());
-            Currency = defaultCurrency = await Queries.QueryAsync(new FindCurrencyDefault());
+            defaultCurrency = await Queries.QueryAsync(new FindCurrencyDefault());
+            if (Value == null)
+                Currency = defaultCurrency;
             StateHasChanged();
         }
     }


### PR DESCRIPTION
When creating an expense from a template with a non-default currency (e.g., EUR when default is CZK), the currency resets to the default as soon as the user switches to the Amount tab. The same issue affects editing existing expenses with non-default currencies.

## Root cause

`AmountBox` is conditionally rendered inside the expense wizard (`if Selected == Amount`), so switching to the Amount tab creates a fresh instance each time. The Blazor lifecycle runs `OnParametersSet` first, correctly setting `Currency` from the parent's `Value` (e.g., "EUR"). However, `AuthenticatedView.OnInitializedAsync` then fires asynchronously, which calls `OnAuthenticationChanged` -- and that method unconditionally overwrites `Currency` with the user's default currency, losing the template/existing value.

## Fix

In `AmountBox.OnAuthenticationChanged`, the default currency is still fetched and stored, but `Currency` is only set to the default when no `Value` has been provided by the parent component:

```csharp
// Before
Currency = defaultCurrency = await Queries.QueryAsync(new FindCurrencyDefault());

// After
defaultCurrency = await Queries.QueryAsync(new FindCurrencyDefault());
if (Value == null)
    Currency = defaultCurrency;
```

Fixes #603