### PR TITLE
Store templates search filter in browser history state

### DIFF
--- a/src/Money.Blazor.Host/Pages/ExpenseTemplates.razor.cs
+++ b/src/Money.Blazor.Host/Pages/ExpenseTemplates.razor.cs
@@ -72,6 +72,8 @@ public partial class ExpenseTemplates(
         CurrencyFormatter = await CurrencyFormatterFactory.CreateAsync();
         SortDescriptor = await Queries.QueryAsync(new GetExpenseTemplateSortProperty());
 
+        SearchQuery = Navigator.GetHistoryEntryState();
+
         using (Loading.Start())
             await ReloadAsync();
     }
@@ -115,7 +117,7 @@ public partial class ExpenseTemplates(
     {
         AllModels.Clear();
         AllModels.AddRange(await Queries.QueryAsync(ListAllExpenseTemplate.Version4(SortDescriptor)));
-        OnSearch();
+        ApplyFilter();
         StateHasChanged();
     }
 
@@ -141,19 +143,27 @@ public partial class ExpenseTemplates(
         return Task.CompletedTask;
     }
 
-    protected void OnSearch()
+    protected async Task OnSearch()
     {
         Log.Debug($"OnSearch '{SearchQuery}'");
 
+        ApplyFilter();
+
+        Navigator.ReplaceHistoryState(SearchQuery);
+        await Task.Yield();
+    }
+
+    private void ApplyFilter()
+    {
         Models.Clear();
         if (String.IsNullOrEmpty(SearchQuery))
         {
             Models.AddRange(AllModels);
-            return;
         }
-
-        string searchQuery = SearchQuery.ToLower().Trim();
-        Models.AddRange(AllModels.Where(m => m.Description.Contains(SearchQuery, StringComparison.CurrentCultureIgnoreCase)));
+        else
+        {
+            Models.AddRange(AllModels.Where(m => m.Description != null && m.Description.Contains(SearchQuery, StringComparison.CurrentCultureIgnoreCase)));
+        }
     }
 
     public Task HandleAsync(ExpenseTemplateCreated payload) => OnEventAsync();

--- a/src/Money.Blazor.Host/Services/Navigator.cs
+++ b/src/Money.Blazor.Host/Services/Navigator.cs
@@ -176,6 +176,12 @@ namespace Money.Services
         public void OpenRegister()
             => manager.NavigateTo(UrlAccountRegister());
 
+        public string GetHistoryEntryState()
+            => manager.HistoryEntryState;
+
+        public void ReplaceHistoryState(string state)
+            => manager.NavigateTo(manager.Uri, new NavigationOptions { ReplaceHistoryEntry = true, HistoryEntryState = state });
+
         public Dictionary<string, StringValues> GetQueryString()
         {
             if (queryString == null)


### PR DESCRIPTION
The ExpenseTemplates page search filter loses its value when navigating away and back. This makes it tedious to work with filtered templates across page transitions.

## Approach

Use Blazor's `NavigationManager.HistoryEntryState` to persist the search filter text in the current browser history entry. The state is saved eagerly on every keystroke (via `ReplaceHistoryState`) and restored on page init.

Key changes:

- **`Navigator.cs`** -- Added `GetHistoryEntryState()` and `ReplaceHistoryState(state)` helper methods wrapping `NavigationManager.HistoryEntryState` and `NavigateTo` with `ReplaceHistoryEntry = true`.
- **`ExpenseTemplates.razor.cs`** -- On init, restores `SearchQuery` from history state. Split filtering into `OnSearch` (user input: filters + saves state) and `ApplyFilter` (pure filtering, used by `ReloadAsync` on data refresh). The `Task.Yield()` before `ReplaceHistoryState` gives the browser a chance to process the state update.

Closes #608