### PR TITLE
Migrate Blazor client app to .NET 10

### DIFF
--- a/src/Money.Blazor.Host/Money.Blazor.Host.csproj
+++ b/src/Money.Blazor.Host/Money.Blazor.Host.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Money</RootNamespace>
     <PublishDomain>app.money.neptuo.com</PublishDomain>
     <VersionPrefix>1.20.0.0</VersionPrefix>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
 	  <WasmFingerprintAssets Condition="'$(Configuration)' == 'Debug'">false</WasmFingerprintAssets>
@@ -13,11 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.1.1" />
     <PackageReference Include="Blazored.SessionStorage" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Money.Blazor.Host/Money.Blazor.Host.csproj
+++ b/src/Money.Blazor.Host/Money.Blazor.Host.csproj
@@ -13,11 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.1.1" />
     <PackageReference Include="Blazored.SessionStorage" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update Money.Blazor.Host from .NET 9 to .NET 10:

- `TargetFramework`: `net9.0` → `net10.0`
- `Microsoft.AspNetCore.Components.Authorization`: `9.0.0` → `10.0.7`
- `Microsoft.AspNetCore.Components.WebAssembly`: `9.0.0` → `10.0.7`
- `Microsoft.AspNetCore.Components.WebAssembly.DevServer`: `9.0.0` → `10.0.7`
- `Microsoft.AspNetCore.SignalR.Client`: `9.0.0` → `10.0.7`
- `Microsoft.AspNetCore.WebUtilities`: `9.0.0` → `10.0.7`

Money.Blazor stays on `netstandard2.1` — it's a pure class library with no framework dependencies.

Closes #624