### PR TITLE
Fix multiple menu items selected for settings and password

### DIFF
--- a/src/Money.Blazor.Host/Bootstrap/BootstrapTask.cs
+++ b/src/Money.Blazor.Host/Bootstrap/BootstrapTask.cs
@@ -75,7 +75,7 @@ namespace Money.Bootstrap
                 .AddTransient<CommandStorage>()
                 .AddTransient<CreateExpenseStorage>()
                 .AddTransient<OfflineCommandDispatcher>()
-                .AddSingleton<LocalCommandDispatcher>()
+                .AddTransient<LocalCommandDispatcher>()
                 .AddTransient<MenuItemService>()
                 .AddSingleton<ICommandHandlerCollection, LocalCommandHandlerCollection>()
                 .AddTransient<ICommandDispatcher, LocalCommandDispatcher>()

--- a/src/Money.Blazor.Host/Layouts/BottomMenu.razor
+++ b/src/Money.Blazor.Host/Layouts/BottomMenu.razor
@@ -8,7 +8,7 @@
                     <div @key="item" class="col d-grid">
                         @if (item.Url != null)
                         {
-                            <Match Url="@item.Url" PageType="@item.PageType" Context="IsActive">
+                            <Match Url="@item.Url" PageType="@item.PageType" Mode="@item.UrlMatch" Context="IsActive">
                                 <a href="@item.Url" class="btn @(IsActive ? "btn-primary" : "bg-light-subtle")" @onclick="(() => OnLinkClick(item.IsBlurMenuAfterClick))">
                                     <Icon Identifier="@item.Icon" />
                                     <span class="text">
@@ -83,7 +83,7 @@
             @<div class="col-3">
                 @if (item.Url != null)
                 {
-                    <Match Url="@item.Url" PageType="@item.PageType" Context="IsActive">
+                    <Match Url="@item.Url" PageType="@item.PageType" Mode="@item.UrlMatch" Context="IsActive">
                         <a href="@item.Url" class="btn @(IsActive ? "btn-primary" : "bg-light-subtle") w-100" @onclick="(() => OnLinkClick(item.IsBlurMenuAfterClick))">
                             <Icon Identifier="@item.Icon" />
                             <span class="small text d-block text-truncate">

--- a/src/Money.Blazor.Host/Layouts/MainMenu.razor
+++ b/src/Money.Blazor.Host/Layouts/MainMenu.razor
@@ -31,7 +31,7 @@
                 </li>
                 @foreach (var item in ViewsItems)
                 {
-                    <MainMenuLink CssClass="d-none d-md-inline-block" href="@item.Url" PageType="@item.PageType">
+                    <MainMenuLink CssClass="d-none d-md-inline-block" href="@item.Url" PageType="@item.PageType" HrefMatch="@item.UrlMatch">
                         <Icon Identifier="@item.Icon" />
                         <span class="d-none d-md-inline">@item.Text</span>
                     </MainMenuLink>
@@ -62,7 +62,7 @@
                 </li>
                 @foreach (var item in MoreItems)
                 {
-                    <MainMenuLink CssClass="d-none d-xl-inline" Href="@item.Url">
+                    <MainMenuLink CssClass="d-none d-xl-inline" Href="@item.Url" HrefMatch="@item.UrlMatch">
                         <Icon Identifier="@item.Icon" />
                         <span class="d-none d-lg-inline">
                             @item.Text

--- a/src/Money.Blazor.Host/Layouts/Match.razor.cs
+++ b/src/Money.Blazor.Host/Layouts/Match.razor.cs
@@ -42,8 +42,8 @@ public partial class Match(NavigationManager NavigationManager) : IDisposable
 
         string currentUrl = "/" + NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
         if (Mode == MatchMode.StartsWith)
-            return currentUrl.StartsWith(Url);
+            return currentUrl.StartsWith(Url, StringComparison.OrdinalIgnoreCase);
 
-        return Url == currentUrl;
+        return string.Equals(Url, currentUrl, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Money.Blazor.Host/Layouts/Match.razor.cs
+++ b/src/Money.Blazor.Host/Layouts/Match.razor.cs
@@ -41,9 +41,9 @@ public partial class Match(NavigationManager NavigationManager) : IDisposable
             return PageType == RouteData.PageType;
 
         string currentUrl = "/" + NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
-        if ((Mode == MatchMode.Exact && Url == currentUrl) || currentUrl.StartsWith(Url))
-            return true;
+        if (Mode == MatchMode.StartsWith)
+            return currentUrl.StartsWith(Url);
 
-        return false;
+        return Url == currentUrl;
     }
 }

--- a/src/Money.Blazor.Host/MenuItems/MenuItemService.cs
+++ b/src/Money.Blazor.Host/MenuItems/MenuItemService.cs
@@ -1,4 +1,5 @@
-﻿using Money.Models;
+﻿using Money.Layouts;
+using Money.Models;
 using Money.Models.Queries;
 using Money.Pages;
 using Money.Services;
@@ -67,7 +68,8 @@ namespace Money
                     Identifier = "search",
                     Icon = "search",
                     Text = "Search",
-                    Url = navigator.UrlSearch()
+                    Url = navigator.UrlSearch(),
+                    UrlMatch = MatchMode.StartsWith
                 },
                 new MenuItemModel()
                 {
@@ -111,7 +113,8 @@ namespace Money
                     new(
                         Text: "Trends",
                         Icon: "chart-line",
-                        Url: navigator.UrlTrends()
+                        Url: navigator.UrlTrends(),
+                        UrlMatch: MatchMode.StartsWith
                     ),
                     new(
                         Text: "Balances",
@@ -122,7 +125,8 @@ namespace Money
                     new(
                         Text: "Search",
                         Icon: "search",
-                        Url: navigator.UrlSearch()
+                        Url: navigator.UrlSearch(),
+                        UrlMatch: MatchMode.StartsWith
                     )
                 ],
                 [

--- a/src/Money.Blazor.Host/MenuItems/Models/IActionMenuItemModel.cs
+++ b/src/Money.Blazor.Host/MenuItems/Models/IActionMenuItemModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Money.Layouts;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,5 +16,6 @@ namespace Money.Models
         Type PageType { get; }
         Action OnClick { get; }
         bool IsBlurMenuAfterClick { get; }
+        MatchMode UrlMatch { get; }
     }
 }

--- a/src/Money.Blazor.Host/MenuItems/Models/MenuItemModel.cs
+++ b/src/Money.Blazor.Host/MenuItems/Models/MenuItemModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Money.Layouts;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,6 +16,7 @@ namespace Money.Models
         Type PageType = null,
         Action OnClick = null,
         bool IsBlurMenuAfterClick = false,
-        bool IsRequired = false
+        bool IsRequired = false,
+        MatchMode UrlMatch = MatchMode.Exact
     ) : IActionMenuItemModel, IAvailableMenuItemModel;
 }


### PR DESCRIPTION
Opening the Settings or Password page also highlights the Profile menu item in the mobile menu and desktop user dropdown. This happens because the `Match` component's `IsActive()` method runs a `StartsWith` URL check unconditionally -- so `/user` matches `/user/settings` and `/user/changepassword`.

The fix makes `StartsWith` only apply when `Mode` is explicitly `MatchMode.StartsWith`. The default `Exact` mode now uses strict URL equality, so only the correct menu item is highlighted.

Also fixes a DI lifetime mismatch: `LocalCommandDispatcher` was registered as singleton but transitively depends on scoped `ApiClient` (via `OfflineCommandDispatcher` → `HttpCommandDispatcher`). .NET 10's `ValidateScopes` catches this at startup. Changed to transient.

Fixes #616