### PR TITLE
Add keyboard arrow navigation to category picker grid

### DIFF
--- a/src/Money.Blazor.Host/Components/ExpenseCreate.razor
+++ b/src/Money.Blazor.Host/Components/ExpenseCreate.razor
@@ -107,7 +107,7 @@
                     <Validation ErrorMessages="@Errors.Category" />
                     if (Categories != null)
                     {
-                        <div class="row g-2">
+                        <div class="row g-2" @ref="CategoryGridRef">
                             @foreach (var category in Categories)
                             {
                                 var buttonId = $"expense-wiz-category-{category.Key.AsGuidKey().Guid.ToString()}";

--- a/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
+++ b/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
@@ -34,6 +34,7 @@ public partial class ExpenseCreate(
     protected IKey EmptyCategoryKey { get; } = KeyFactory.Empty(typeof(Category));
 
     protected ElementReference CategoryGridRef;
+    private bool categoryGridNavInitialized;
 
     [Parameter][CascadingParameter]
     public Navigator.ComponentContainer ComponentContainer { get; set; }
@@ -90,8 +91,11 @@ public partial class ExpenseCreate(
             FocusAfterRender = false;
         }
 
-        if (Selected == SelectedField.Category)
+        if (!categoryGridNavInitialized && Selected == SelectedField.Category && Categories != null)
+        {
+            categoryGridNavInitialized = true;
             await Interop.SetupGridNavigationAsync(CategoryGridRef);
+        }
     }
 
     protected bool FocusAfterRender;
@@ -340,6 +344,7 @@ public partial class ExpenseCreate(
 
     private void ClearValues(bool clearWhenToMinValue = false)
     {
+        categoryGridNavInitialized = false;
         SuggestedTemplates.Clear();
         Description = null;
         Amount = null;

--- a/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
+++ b/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
@@ -75,7 +75,11 @@ public partial class ExpenseCreate(
             {
                 SelectedField.Description => "expense-wiz-description",
                 SelectedField.Amount => "expense-wiz-amount",
-                SelectedField.Category => !CategoryKey.IsEmpty ? $"expense-wiz-category-{CategoryKey.AsGuidKey().Guid.ToString()}" : null,
+                SelectedField.Category => !CategoryKey.IsEmpty 
+                    ? $"expense-wiz-category-{CategoryKey.AsGuidKey().Guid.ToString()}" 
+                    : Categories?.Count > 0 
+                        ? $"expense-wiz-category-{Categories[0].Key.AsGuidKey().Guid.ToString()}" 
+                        : null,
                 SelectedField.When => "expense-wiz-when",
                 _ => null,
             };

--- a/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
+++ b/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
@@ -33,6 +33,7 @@ public partial class ExpenseCreate(
 {
     protected IKey EmptyCategoryKey { get; } = KeyFactory.Empty(typeof(Category));
 
+    protected ElementReference CategoryGridRef;
 
     [Parameter][CascadingParameter]
     public Navigator.ComponentContainer ComponentContainer { get; set; }
@@ -84,6 +85,9 @@ public partial class ExpenseCreate(
 
             FocusAfterRender = false;
         }
+
+        if (Selected == SelectedField.Category)
+            await Interop.SetupGridNavigationAsync(CategoryGridRef);
     }
 
     protected bool FocusAfterRender;

--- a/src/Money.Blazor.Host/Interop.cs
+++ b/src/Money.Blazor.Host/Interop.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.JSInterop;
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using Neptuo;
 using System;
 using System.Collections.Generic;
@@ -35,6 +36,9 @@ namespace Money
 
         public async Task FocusElementByIdAsync(string id)
             => await jsRuntime.InvokeVoidAsync("Money.FocusElementById", id);
+
+        public async Task SetupGridNavigationAsync(ElementReference element)
+            => await jsRuntime.InvokeVoidAsync("GridNavigation.Setup", element);
 
         public async Task ApplyThemeAsync(string theme)
             => await jsRuntime.InvokeVoidAsync("Bootstrap.Theme.Apply", theme);

--- a/src/Money.Blazor.Host/wwwroot/js/site.js
+++ b/src/Money.Blazor.Host/wwwroot/js/site.js
@@ -156,6 +156,49 @@ window.AutoloadNext = {
     }
 };
 
+window.GridNavigation = {
+    Setup: function (container) {
+        if (!container || container._gridNavInitialized) return;
+        container._gridNavInitialized = true;
+
+        container.addEventListener("keydown", function (e) {
+            const key = e.key;
+            if (key !== "ArrowUp" && key !== "ArrowDown" && key !== "ArrowLeft" && key !== "ArrowRight") return;
+
+            const buttons = Array.from(container.querySelectorAll("button"));
+            if (buttons.length === 0) return;
+
+            const index = buttons.indexOf(document.activeElement);
+            if (index < 0) return;
+
+            // Determine number of columns by counting buttons sharing the same top offset as the first button
+            const firstTop = buttons[0].getBoundingClientRect().top;
+            let cols = 0;
+            for (let i = 0; i < buttons.length; i++) {
+                if (Math.abs(buttons[i].getBoundingClientRect().top - firstTop) < 2) {
+                    cols++;
+                } else {
+                    break;
+                }
+            }
+            if (cols < 1) cols = 1;
+
+            let next = -1;
+            switch (key) {
+                case "ArrowRight": next = index + 1; break;
+                case "ArrowLeft": next = index - 1; break;
+                case "ArrowDown": next = index + cols; break;
+                case "ArrowUp": next = index - cols; break;
+            }
+
+            if (next >= 0 && next < buttons.length) {
+                e.preventDefault();
+                buttons[next].focus();
+            }
+        });
+    }
+};
+
 window.Money = {
     ApplicationStarted: function () {
         isLoaded = true;

--- a/src/Money.Blazor.Host/wwwroot/js/site.js
+++ b/src/Money.Blazor.Host/wwwroot/js/site.js
@@ -171,6 +171,8 @@ window.GridNavigation = {
             const index = buttons.indexOf(document.activeElement);
             if (index < 0) return;
 
+            e.preventDefault();
+
             // Determine number of columns by counting buttons sharing the same top offset as the first button
             const firstTop = buttons[0].getBoundingClientRect().top;
             let cols = 0;
@@ -192,7 +194,6 @@ window.GridNavigation = {
             }
 
             if (next >= 0 && next < buttons.length) {
-                e.preventDefault();
                 buttons[next].focus();
             }
         });


### PR DESCRIPTION
Currently users can only use TAB to jump between category buttons one by one. Since the buttons are displayed in a responsive grid (2 columns on mobile, 3 on desktop), arrow keys should navigate the grid spatially.

## Approach

A lightweight JS function (`GridNavigation.Setup`) attaches a `keydown` listener to the category grid container. On each arrow press it:

- Counts how many buttons share the same vertical offset as the first button to determine the current column count (responsive-aware -- no hardcoded breakpoints)
- Moves focus: Left/Right step within the row, Up/Down jump by column count

The function is called from C# via `Interop.SetupGridNavigationAsync` after the Category tab renders in `ExpenseCreate`. When the tab opens, focus is placed on the already-selected category button, or the first button if none is selected, so arrow navigation works immediately.

Only `ExpenseCreate` is wired up for now -- the same pattern can be extended to `OutcomeCreate` and `ExpenseTemplateCategory` later.

Closes #542