### PR TITLE
Reduce placeholders in Overview for future periods

### DIFF
--- a/src/Money.Blazor.Host/Pages/Overview.razor
+++ b/src/Money.Blazor.Host/Pages/Overview.razor
@@ -62,6 +62,7 @@
         <ExpenseCardContext>
             <AutoLoadListView
                 Items="@Items"
+                PlaceholderCount="@(IsFuturePeriod() ? 1 : null)"
                 LoadingContext="@Loading"
                 PagingContext="@PagingContext"
                 NoDataTitle="No data."

--- a/src/Money.Blazor.Host/Pages/Overview.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Overview.razor.cs
@@ -251,6 +251,9 @@ public partial class Overview<T>(
         });
     }
 
+    protected virtual bool IsFuturePeriod()
+        => false;
+
     protected virtual bool IsContained(DateTime when)
         => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(IsContained)}'.");
 

--- a/src/Money.Blazor.Host/Pages/OverviewMonth.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewMonth.cs
@@ -62,6 +62,9 @@ public partial class OverviewMonth(
     protected override IQuery<List<OutcomeOverviewModel>> CreateItemsQuery(int pageIndex)
         => ListMonthOutcomeFromCategory.Version3(CategoryKey, SelectedPeriod, SortDescriptor, pageIndex);
 
+    protected override bool IsFuturePeriod()
+        => SelectedPeriod > DateTime.Now;
+
     protected override bool IsContained(DateTime when)
         => SelectedPeriod == when;
 

--- a/src/Money.Blazor.Host/Pages/OverviewYear.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewYear.cs
@@ -55,6 +55,9 @@ public partial class OverviewYear(
     protected override IQuery<List<OutcomeOverviewModel>> CreateItemsQuery(int pageIndex)
         => ListYearOutcomeFromCategory.Version3(CategoryKey, SelectedPeriod, SortDescriptor, pageIndex);
 
+    protected override bool IsFuturePeriod()
+        => SelectedPeriod > DateTime.Now;
+
     protected override bool IsContained(DateTime when)
         => SelectedPeriod == when;
 


### PR DESCRIPTION
When viewing a future period on the Overview page, 5 placeholder items flash during loading and then immediately get replaced with "No data." Since future periods almost never have data, this creates a jarring experience.

This change passes `PlaceholderCount=1` to `AutoLoadListView` when the selected period is in the future, keeping the default behavior (5 initial, 2 on subsequent loads) for current and past periods.

**Approach:** Added a virtual `IsFuturePeriod()` method to the `Overview<T>` base class, overridden in `OverviewMonth` and `OverviewYear` to compare the selected period against `DateTime.Now` using the existing `>` operators on `MonthModel`/`YearModel`.

Fixes #597