### PR TITLE
Fix expense templates not re-rendering when filtered (#609)

### DIFF
--- a/src/Money.Blazor.Host/Pages/ExpenseTemplates.razor.cs
+++ b/src/Money.Blazor.Host/Pages/ExpenseTemplates.razor.cs
@@ -139,8 +139,7 @@ public partial class ExpenseTemplates(
     protected Task OnEventAsync()
     {
         Log.Debug($"OnEventAsync");
-        _ = ReloadAsync();
-        return Task.CompletedTask;
+        return InvokeAsync(ReloadAsync);
     }
 
     protected async Task OnSearch()


### PR DESCRIPTION
When expense templates are filtered via the search box and an event arrives (e.g., a template's amount or description is changed), the view does not update to reflect the change.

## Approach

The root cause is that `OnEventAsync` used fire-and-forget (`_ = ReloadAsync()`) to handle incoming events. This meant `StateHasChanged()` inside `ReloadAsync` was called outside of Blazor's render synchronization context -- the events arrive from SignalR's callback chain, not from Blazor's component lifecycle.

The fix replaces the fire-and-forget with `InvokeAsync(ReloadAsync)`, which marshals the reload work onto the component's render context. This ensures `StateHasChanged()` properly triggers a re-render after the data is reloaded and the filter is re-applied.

## Change

One-line change in `ExpenseTemplates.razor.cs`:

```diff
-  _ = ReloadAsync();
-  return Task.CompletedTask;
+  return InvokeAsync(ReloadAsync);
```

Closes #609