### PR TITLE
Fix build warnings: CS9107, CS0618, and NuGet vulnerabilities

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.1.1" />
     <PackageVersion Include="Blazored.SessionStorage" Version="2.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
@@ -22,9 +22,10 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Money.Accounts.EntityFrameworkCore/Migrations/00000000000000_CreateIdentitySchema.Designer.cs
+++ b/src/Money.Accounts.EntityFrameworkCore/Migrations/00000000000000_CreateIdentitySchema.Designer.cs
@@ -33,7 +33,7 @@ namespace Money.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("NormalizedName")
-                        .HasName("RoleNameIndex");
+                        .HasDatabaseName("RoleNameIndex");
 
                     b.ToTable("AspNetRoles");
                 });
@@ -164,11 +164,11 @@ namespace Money.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("NormalizedEmail")
-                        .HasName("EmailIndex");
+                        .HasDatabaseName("EmailIndex");
 
                     b.HasIndex("NormalizedUserName")
                         .IsUnique()
-                        .HasName("UserNameIndex");
+                        .HasDatabaseName("UserNameIndex");
 
                     b.ToTable("AspNetUsers");
                 });

--- a/src/Money.Blazor.Host/Pages/Overview.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Overview.razor.cs
@@ -39,6 +39,8 @@ public partial class Overview<T>(
     IEventHandler<SwipedLeft>,
     IEventHandler<SwipedRight>
 {
+    protected Navigator Navigator { get; } = Navigator;
+    protected ILog<Overview<T>> Log { get; } = Log;
     protected string Title { get; set; }
     protected string SubTitle { get; set; } = subTitle;
 

--- a/src/Money.Blazor.Host/Pages/OverviewMonth.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewMonth.cs
@@ -27,14 +27,14 @@ public partial class OverviewMonth(
     IEventHandlerCollection EventHandlers,
     IQueryDispatcher Queries,
     Interop Interop,
-    Navigator Navigator,
-    ILog<Overview<MonthModel>> Log
+    Navigator navigator,
+    ILog<Overview<MonthModel>> log
 ) : Overview<MonthModel>(
     EventHandlers,
     Queries,
     Interop,
-    Navigator,
-    Log,
+    navigator,
+    log,
     "List of each single expense in selected month"
 )
 {

--- a/src/Money.Blazor.Host/Pages/OverviewYear.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewYear.cs
@@ -24,14 +24,14 @@ public partial class OverviewYear(
     IEventHandlerCollection EventHandlers,
     IQueryDispatcher Queries,
     Interop Interop,
-    Navigator Navigator,
-    ILog<Overview<YearModel>> Log
+    Navigator navigator,
+    ILog<Overview<YearModel>> log
 ) : Overview<YearModel>(
     EventHandlers,
     Queries,
     Interop,
-    Navigator,
-    Log,
+    navigator,
+    log,
     "List of each single expense in selected year"
 )
 {

--- a/src/Money.Blazor.Host/Pages/Summary.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Summary.razor.cs
@@ -39,6 +39,8 @@ public partial class Summary<T>(
     IEventHandler<IncomeCreated>,
     IEventHandler<IncomeDeleted>
 {
+    protected ILog<Summary<T>> Log { get; } = Log;
+    protected Navigator Navigator { get; } = Navigator;
     protected string SubTitle { get; set; } = subTitle;
 
     protected bool IsPeriodReloadRequired { get; set; }

--- a/src/Money.Blazor.Host/Pages/SummaryMonth.cs
+++ b/src/Money.Blazor.Host/Pages/SummaryMonth.cs
@@ -22,13 +22,13 @@ namespace Money.Pages;
 public class SummaryMonth(
     IEventHandlerCollection EventHandlers,
     IQueryDispatcher Queries,
-    ILog<Summary<MonthModel>> Log,
-    Navigator Navigator
+    ILog<Summary<MonthModel>> log,
+    Navigator navigator
 ) : Summary<MonthModel>(
     EventHandlers,
     Queries,
-    Log,
-    Navigator,
+    log,
+    navigator,
     "Per-month summary of expenses in categories"
 )
 {

--- a/src/Money.Blazor.Host/Pages/SummaryYear.cs
+++ b/src/Money.Blazor.Host/Pages/SummaryYear.cs
@@ -21,13 +21,13 @@ namespace Money.Pages;
 public class SummaryYear(
     IEventHandlerCollection EventHandlers,
     IQueryDispatcher Queries,
-    ILog<Summary<YearModel>> Log,
-    Navigator Navigator
+    ILog<Summary<YearModel>> log,
+    Navigator navigator
 ) : Summary<YearModel>(
     EventHandlers,
     Queries,
-    Log,
-    Navigator,
+    log,
+    navigator,
     "Per-year summary of expenses in categories"
 )
 {

--- a/src/Money.EventSourcing.EntityFrameworkCore/Money.EventSourcing.EntityFrameworkCore.csproj
+++ b/src/Money.EventSourcing.EntityFrameworkCore/Money.EventSourcing.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-    <PackageReference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Money.EventSourcing.EntityFrameworkCore/Money.EventSourcing.EntityFrameworkCore.csproj
+++ b/src/Money.EventSourcing.EntityFrameworkCore/Money.EventSourcing.EntityFrameworkCore.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The build produced CS9107 warnings (primary constructor double-capture), CS0618 warnings (obsolete API usage), and NuGet vulnerability advisories (NU1902/NU1903). This PR eliminates all of them.

## Approach

**CS9107 -- primary constructor parameter captured in both base and derived class:**
Added `protected` properties for `Log` and `Navigator` in the base classes (`Summary<T>`, `Overview<T>`). Renamed parameters in derived classes (`SummaryMonth`, `SummaryYear`, `OverviewMonth`, `OverviewYear`) to lowercase so they are only passed through to base and never double-captured.

**CS0618 -- obsolete `HasName()` in EF Core migration:**
Replaced with `HasDatabaseName()` in the identity schema migration designer.

**NuGet vulnerabilities:**
- `OpenTelemetry.Extensions.Hosting` 1.10.0 -> 1.15.3
- `OpenTelemetry.Instrumentation.AspNetCore` 1.10.1 -> 1.15.2
- `Azure.Monitor.OpenTelemetry.AspNetCore` 1.2.0 -> 1.4.0
- Pinned transitive `System.Security.Cryptography.Xml` to 10.0.7 (was 9.0.0 with high-severity CVEs)