### PR TITLE
Fix currency list not updating in expense wizard after creation

### DIFF
--- a/src/Money.Blazor.Host/Components/AmountBox.razor
+++ b/src/Money.Blazor.Host/Components/AmountBox.razor
@@ -3,7 +3,7 @@
         <input type="text" class="form-control" id="@Id" value="@Amount.ToString("F" + DecimalDigits)" @onchange="OnValueChanged" data-autofocus="@AutoFocus" data-select="@AutoSelect" autocomplete="off" />
         @if (Currencies != null)
         {
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-popper-config='{"strategy":"fixed"}'>
                 @Currencies.FirstOrDefault(c => c.UniqueCode == Currency)?.Symbol
             </button>
             <div class="dropdown-menu dropdown-menu-end z-1030">

--- a/src/Money.Blazor.Host/Components/AmountBox.razor.cs
+++ b/src/Money.Blazor.Host/Components/AmountBox.razor.cs
@@ -133,6 +133,27 @@ public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries, IE
             if (model != null)
                 Currencies.Remove(model);
 
+            if (Currency == payload.UniqueCode)
+            {
+                if (defaultCurrency != null && Currencies.Any(c => c.UniqueCode == defaultCurrency))
+                {
+                    Currency = defaultCurrency;
+                    Value = new Price(Amount, Currency);
+                }
+                else if (Currencies.Count > 0)
+                {
+                    Currency = Currencies[0].UniqueCode;
+                    Value = new Price(Amount, Currency);
+                }
+                else
+                {
+                    Currency = null;
+                    Value = null;
+                }
+
+                ValueChanged?.Invoke(Value);
+            }
+
             StateHasChanged();
         }
 

--- a/src/Money.Blazor.Host/Components/AmountBox.razor.cs
+++ b/src/Money.Blazor.Host/Components/AmountBox.razor.cs
@@ -1,8 +1,11 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Money.Events;
 using Money.Models;
 using Money.Models.Queries;
 using Money.Pages;
 using Money.Queries;
+using Neptuo.Events;
+using Neptuo.Events.Handlers;
 using Neptuo.Logging;
 using Neptuo.Queries;
 using System;
@@ -16,7 +19,10 @@ using System.Threading.Tasks;
 
 namespace Money.Components;
 
-public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries)
+public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries, IEventHandlerCollection EventHandlers) :
+    IDisposable,
+    IEventHandler<CurrencyCreated>,
+    IEventHandler<CurrencyDeleted>
 {
     [Parameter]
     public string Id { get; set; }
@@ -39,6 +45,22 @@ public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries)
     protected List<CurrencyModel> Currencies { get; private set; }
 
     private string defaultCurrency = null;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        EventHandlers
+            .Add<CurrencyCreated>(this)
+            .Add<CurrencyDeleted>(this);
+    }
+
+    public void Dispose()
+    {
+        EventHandlers
+            .Remove<CurrencyCreated>(this)
+            .Remove<CurrencyDeleted>(this);
+    }
 
     protected async void OnAuthenticationChanged(bool isAuthenticated)
     {
@@ -90,5 +112,27 @@ public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries)
             Currency = currency.UniqueCode;
             ValueChanged?.Invoke(Value = new Price(Amount, Currency));
         }
+    }
+
+    Task IEventHandler<CurrencyCreated>.HandleAsync(CurrencyCreated payload)
+    {
+        Currencies ??= new List<CurrencyModel>();
+        Currencies.Add(new CurrencyModel(payload.UniqueCode, payload.Symbol, false));
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    Task IEventHandler<CurrencyDeleted>.HandleAsync(CurrencyDeleted payload)
+    {
+        if (Currencies != null)
+        {
+            var model = Currencies.FirstOrDefault(c => c.UniqueCode == payload.UniqueCode);
+            if (model != null)
+                Currencies.Remove(model);
+
+            StateHasChanged();
+        }
+
+        return Task.CompletedTask;
     }
 }

--- a/src/Money.Blazor.Host/Components/AmountBox.razor.cs
+++ b/src/Money.Blazor.Host/Components/AmountBox.razor.cs
@@ -22,7 +22,8 @@ namespace Money.Components;
 public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries, IEventHandlerCollection EventHandlers) :
     IDisposable,
     IEventHandler<CurrencyCreated>,
-    IEventHandler<CurrencyDeleted>
+    IEventHandler<CurrencyDeleted>,
+    IEventHandler<CurrencyDefaultChanged>
 {
     [Parameter]
     public string Id { get; set; }
@@ -52,14 +53,16 @@ public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries, IE
 
         EventHandlers
             .Add<CurrencyCreated>(this)
-            .Add<CurrencyDeleted>(this);
+            .Add<CurrencyDeleted>(this)
+            .Add<CurrencyDefaultChanged>(this);
     }
 
     public void Dispose()
     {
         EventHandlers
             .Remove<CurrencyCreated>(this)
-            .Remove<CurrencyDeleted>(this);
+            .Remove<CurrencyDeleted>(this)
+            .Remove<CurrencyDefaultChanged>(this);
     }
 
     protected async void OnAuthenticationChanged(bool isAuthenticated)
@@ -130,6 +133,19 @@ public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries, IE
             if (model != null)
                 Currencies.Remove(model);
 
+            StateHasChanged();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    Task IEventHandler<CurrencyDefaultChanged>.HandleAsync(CurrencyDefaultChanged payload)
+    {
+        defaultCurrency = payload.UniqueCode;
+
+        if (Value == null)
+        {
+            Currency = defaultCurrency;
             StateHasChanged();
         }
 

--- a/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
+++ b/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.VisualBasic;
 using Money.Commands;
+using Money.Events;
 using Money.Models;
 using Money.Models.Queries;
 using Money.Models.Sorting;
@@ -8,6 +9,8 @@ using Money.Pages;
 using Money.Services;
 using Neptuo;
 using Neptuo.Commands;
+using Neptuo.Events;
+using Neptuo.Events.Handlers;
 using Neptuo.Logging;
 using Neptuo.Models.Keys;
 using Neptuo.Queries;
@@ -28,8 +31,11 @@ public partial class ExpenseCreate(
     Interop Interop,
     Navigator Navigator,
     ICommandDispatcher Commands,
-    IQueryDispatcher Queries
-) : System.IDisposable, IExpenseCreateNavigator
+    IQueryDispatcher Queries,
+    IEventHandlerCollection EventHandlers
+) : System.IDisposable, IExpenseCreateNavigator,
+    IEventHandler<CurrencyCreated>,
+    IEventHandler<CurrencyDeleted>
 {
     protected IKey EmptyCategoryKey { get; } = KeyFactory.Empty(typeof(Category));
 
@@ -62,6 +68,10 @@ public partial class ExpenseCreate(
             Log.Debug("Attach to component container");
             ComponentContainer.ExpenseCreate = this;
         }
+
+        EventHandlers
+            .Add<CurrencyCreated>(this)
+            .Add<CurrencyDeleted>(this);
     }
 
     protected async override Task OnAfterRenderAsync(bool firstRender)
@@ -93,6 +103,10 @@ public partial class ExpenseCreate(
         Log.Debug("Dispose");
         if (ComponentContainer != null && ComponentContainer.ExpenseCreate == this)
             ComponentContainer.ExpenseCreate = null;
+
+        EventHandlers
+            .Remove<CurrencyCreated>(this)
+            .Remove<CurrencyDeleted>(this);
     }
 
     private async void ShowInternal(Func<bool> setParameters = null)
@@ -348,5 +362,27 @@ public partial class ExpenseCreate(
             Navigator.OpenCurrencies();
         else if (Categories == null || Categories.Count == 0)
             Navigator.OpenCategories();
+    }
+
+    Task IEventHandler<CurrencyCreated>.HandleAsync(CurrencyCreated payload)
+    {
+        Currencies ??= new List<CurrencyModel>();
+        Currencies.Add(new CurrencyModel(payload.UniqueCode, payload.Symbol, false));
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    Task IEventHandler<CurrencyDeleted>.HandleAsync(CurrencyDeleted payload)
+    {
+        if (Currencies != null)
+        {
+            var model = Currencies.FirstOrDefault(c => c.UniqueCode == payload.UniqueCode);
+            if (model != null)
+                Currencies.Remove(model);
+
+            StateHasChanged();
+        }
+
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
When a user creates a new currency while the expense wizard (`ExpenseCreate`) is open, the currency dropdown in the `AmountBox` component does not reflect the new currency until the page is reloaded.

## Approach

Both `ExpenseCreate` and `AmountBox` loaded their currency lists once (on dialog open / on auth) and never listened for changes. The fix subscribes both components to `CurrencyCreated` and `CurrencyDeleted` events -- the same event-handler pattern already used by the `Currencies` page and `ExchangeRateList` component.

- **`AmountBox.razor.cs`** -- implements `IEventHandler<CurrencyCreated>` and `IEventHandler<CurrencyDeleted>`, registers in `OnInitialized`, unregisters in `Dispose`, and updates the local `Currencies` list on each event.
- **`ExpenseCreate.razor.cs`** -- same pattern, so the prerequisites check (`Currencies.Count == 0`) stays accurate if the wizard is already open when a currency is created elsewhere.