### PR TITLE
Fix Create button in expense wizard triggering tab navigation

### DIFF
--- a/src/Money.Blazor.Host/Components/Button.razor
+++ b/src/Money.Blazor.Host/Components/Button.razor
@@ -11,7 +11,7 @@
     }
 }
 
-<button type="@(IsPrimary ? "submit" : "button")" class="@cssClass" disabled="@(isSaving && IsPrimary)" @onclick="OnClickAsync" @onclick:preventDefault="@(IsPrimary && OnClick.HasDelegate)">
+<button type="@(Type ?? (IsPrimary ? "submit" : "button"))" class="@cssClass" disabled="@(isSaving && IsPrimary)" @onclick="OnClickAsync" @onclick:preventDefault="@(IsPrimary && OnClick.HasDelegate)">
     @if (isSaving && IsPrimary)
     {
         <span class="btn-loading-text">@ChildContent</span>
@@ -32,6 +32,9 @@
 
     [Parameter]
     public bool IsPrimary { get; set; }
+
+    [Parameter]
+    public string Type { get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/src/Money.Blazor.Host/Components/ExpenseCreate.razor
+++ b/src/Money.Blazor.Host/Components/ExpenseCreate.razor
@@ -31,7 +31,7 @@
     }
 }
 
-<Form OnSubmit="@OnFormSubmitAsync">
+<Form @ref="FormRef" OnSubmit="@OnFormSubmitAsync">
     <Modal @ref="Modal" Title="Create a new Expense" BodyCssClass="px-1 py-0" IsOverflow="true" IsForm="false" IsCloseButton="false">
         <ChildContent>
             <div class="sticky-top mb-2 bg-body">
@@ -137,7 +137,8 @@
             </div>
         </ChildContent>
         <Buttons>
-            <Button IsPrimary="true">Create</Button>
+            <input type="submit" hidden />
+            <Button IsPrimary="true" Type="button" OnClick="OnCreateClickAsync">Create</Button>
             <button type="button" class="btn" @onclick="@(() => ClearValues())">Clear</button>
         </Buttons>
     </Modal>

--- a/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
+++ b/src/Money.Blazor.Host/Components/ExpenseCreate.razor.cs
@@ -42,6 +42,8 @@ public partial class ExpenseCreate(
     protected ElementReference CategoryGridRef;
     private bool categoryGridNavInitialized;
 
+    protected Form FormRef { get; set; }
+
     [Parameter][CascadingParameter]
     public Navigator.ComponentContainer ComponentContainer { get; set; }
 
@@ -314,6 +316,8 @@ public partial class ExpenseCreate(
                 return Task.CompletedTask;
         }
     }
+
+    protected Task OnCreateClickAsync() => FormRef.RunAsync(CreateAsync);
 
     protected async Task CreateAsync()
     {

--- a/src/Money.Blazor.Host/Components/Form.razor.cs
+++ b/src/Money.Blazor.Host/Components/Form.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using System;
 using System.Threading.Tasks;
 
 namespace Money.Components;
@@ -14,6 +15,25 @@ public partial class Form
     public bool IsSaving { get; private set; }
 
     public Task SubmitAsync() => OnFormSubmitAsync();
+
+    public async Task RunAsync(Func<Task> action)
+    {
+        if (IsSaving)
+            return;
+
+        IsSaving = true;
+        StateHasChanged();
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            IsSaving = false;
+            StateHasChanged();
+        }
+    }
 
     protected async Task OnFormSubmitAsync()
     {

--- a/src/Money.Blazor.Host/Components/Form.razor.cs
+++ b/src/Money.Blazor.Host/Components/Form.razor.cs
@@ -18,6 +18,8 @@ public partial class Form
 
     public async Task RunAsync(Func<Task> action)
     {
+        ArgumentNullException.ThrowIfNull(action);
+
         if (IsSaving)
             return;
 
@@ -35,22 +37,5 @@ public partial class Form
         }
     }
 
-    protected async Task OnFormSubmitAsync()
-    {
-        if (IsSaving)
-            return;
-
-        IsSaving = true;
-        StateHasChanged();
-
-        try
-        {
-            await OnSubmit.InvokeAsync();
-        }
-        finally
-        {
-            IsSaving = false;
-            StateHasChanged();
-        }
-    }
+    protected Task OnFormSubmitAsync() => RunAsync(() => OnSubmit.InvokeAsync());
 }


### PR DESCRIPTION
## Motivation

Clicking the "Create" button in the expense wizard was navigating to the next tab instead of validating and creating the expense. This was a regression from #626 which introduced the Form component with type=submit buttons -- pressing Enter in any field also triggered validation via the button click instead of advancing tabs.

## Approach

The root cause is HTML's implicit form submission: the browser fires a click on the first type=submit button when Enter is pressed in a text input. Since the Create button was both the submit button and had an OnClick handler, both Enter and direct clicks went through CreateAsync instead of the form's OnFormSubmitAsync tab navigation.

The fix separates the two paths:

- **Click "Create" button** -- The button is now type=button, so it does not participate in form submission. Its OnClick handler calls CreateAsync through Form.RunAsync to get the saving/disabled state on the form.
- **Press Enter** -- A hidden `<input type="submit" />` ensures the browser's implicit submission still fires the form's @onsubmit handler, which navigates to the next tab as intended.

### Changes

- **Button.razor** -- Added optional Type parameter to override the default button type
- **Form.razor.cs** -- Added RunAsync(Func\<Task\>) so external callers can wrap an action with the IsSaving disabled state
- **ExpenseCreate.razor** -- Set Create button to Type=button, added hidden submit input, wired up OnClick through Form.RunAsync
- **ExpenseCreate.razor.cs** -- Added FormRef property and OnCreateClickAsync method