### PR TITLE
Add income search feature

### DIFF
--- a/src/Money.Api.Shared/Api/Routing/QueryMapper.cs
+++ b/src/Money.Api.Shared/Api/Routing/QueryMapper.cs
@@ -50,6 +50,7 @@ namespace Money.Api.Routing
             Add<GetMonthExpectedExpenseTotal>("month-expected-expense-total");
 
             Add<SearchOutcomes>("search-outcomes");
+            Add<SearchIncomes>("search-incomes");
 
             Add<GetProfile>("user-profile");
             Add<ListUserProperty>("user-properties");

--- a/src/Money.Api/appsettings.json
+++ b/src/Money.Api/appsettings.json
@@ -22,6 +22,7 @@
     "SummaryDisplay",
     "ExpenseOverviewSort",
     "SearchSort",
+    "SearchIncomesSort",
     "BalanceDisplay",
     "ExpenseTemplateSort",
     "ExpenseTemplateCalendarDisplay",

--- a/src/Money.Blazor.Host/Components/IncomeCard.razor
+++ b/src/Money.Blazor.Host/Components/IncomeCard.razor
@@ -1,0 +1,47 @@
+﻿@if (Model != null)
+{
+    <div @key="Model" class="row align-items-center py-3 @CssClass">
+        <div class="col-4 col-md-2 mb-2 mb-md-0">
+            <DateValue Value="Model.When" />
+        </div>
+        <div class="col-8 col-md-3 text-md-end mb-2 mb-md-0 text-end">
+            <PriceView TagName="h3" CssClass="m-0" Value="Model.Amount" />
+        </div>
+        <div class="col-md-1"></div>
+        <div class="col mb-2 mb-md-0">
+            @Model.Description
+        </div>
+        @if (Context.HasEdit && !Model.Key.IsEmpty)
+        {
+            <div class="col-12 col-sm-auto controls text-end">
+                <div class="sort dropdown">
+                    <IconButton Icon="ellipsis-v" data-bs-toggle="dropdown" />
+                    <div class="dropdown-menu dropdown-menu-end">
+                        <a class="dropdown-item" @onclick="@OnEditAmount">
+                            <Icon Identifier="dollar-sign" />
+                            Amount
+                        </a>
+                        <a class="dropdown-item" @onclick="@OnEditDescription">
+                            <Icon Identifier="comment" />
+                            Description
+                        </a>
+                        <a class="dropdown-item" @onclick="@OnEditWhen">
+                            <Icon Identifier="calendar" />
+                            When
+                        </a>
+                        <hr class="dropdown-divider" />
+                        <a class="dropdown-item" href="@Navigator.UrlSearchIncomes(Model.Description)">
+                            <Icon Identifier="search" />
+                            Find similar
+                        </a>
+                        <hr class="dropdown-divider" />
+                        <a class="dropdown-item" @onclick="@OnDelete">
+                            <Icon Identifier="trash-alt" />
+                            Delete
+                        </a>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+}

--- a/src/Money.Blazor.Host/Components/IncomeCard.razor
+++ b/src/Money.Blazor.Host/Components/IncomeCard.razor
@@ -2,45 +2,58 @@
 {
     <div @key="Model" class="row align-items-center py-3 @CssClass">
         <div class="col-4 col-md-2 mb-2 mb-md-0">
-            <DateValue Value="Model.When" />
+            <Placeholder WordMinLength="6" WordMaxLength="7">
+                <DateValue Value="Model.When" />
+            </Placeholder>
         </div>
         <div class="col-8 col-md-3 text-md-end mb-2 mb-md-0 text-end">
-            <PriceView TagName="h3" CssClass="m-0" Value="Model.Amount" />
+            <Placeholder WordMinLength="7">
+                <PriceView TagName="h3" CssClass="m-0" Value="Model.Amount" />
+            </Placeholder>
         </div>
         <div class="col-md-1"></div>
         <div class="col mb-2 mb-md-0">
-            @Model.Description
+            <Placeholder WordMinCount="2" WordMaxCount="4" WordMinLength="2" WordMaxLength="5" TotalMaxLength="11">
+                @Model.Description
+            </Placeholder>
         </div>
         @if (Context.HasEdit && !Model.Key.IsEmpty)
         {
             <div class="col-12 col-sm-auto controls text-end">
-                <div class="sort dropdown">
-                    <IconButton Icon="ellipsis-v" data-bs-toggle="dropdown" />
-                    <div class="dropdown-menu dropdown-menu-end">
-                        <a class="dropdown-item" @onclick="@OnEditAmount">
-                            <Icon Identifier="dollar-sign" />
-                            Amount
-                        </a>
-                        <a class="dropdown-item" @onclick="@OnEditDescription">
-                            <Icon Identifier="comment" />
-                            Description
-                        </a>
-                        <a class="dropdown-item" @onclick="@OnEditWhen">
-                            <Icon Identifier="calendar" />
-                            When
-                        </a>
-                        <hr class="dropdown-divider" />
-                        <a class="dropdown-item" href="@Navigator.UrlSearchIncomes(Model.Description)">
-                            <Icon Identifier="search" />
-                            Find similar
-                        </a>
-                        <hr class="dropdown-divider" />
-                        <a class="dropdown-item" @onclick="@OnDelete">
-                            <Icon Identifier="trash-alt" />
-                            Delete
-                        </a>
-                    </div>
-                </div>
+                <Placeholder>
+                    <ChildContent>
+                        <div class="sort dropdown">
+                            <IconButton Icon="ellipsis-v" data-bs-toggle="dropdown" />
+                            <div class="dropdown-menu dropdown-menu-end">
+                                <a class="dropdown-item" @onclick="@OnEditAmount">
+                                    <Icon Identifier="dollar-sign" />
+                                    Amount
+                                </a>
+                                <a class="dropdown-item" @onclick="@OnEditDescription">
+                                    <Icon Identifier="comment" />
+                                    Description
+                                </a>
+                                <a class="dropdown-item" @onclick="@OnEditWhen">
+                                    <Icon Identifier="calendar" />
+                                    When
+                                </a>
+                                <hr class="dropdown-divider" />
+                                <a class="dropdown-item" href="@Navigator.UrlSearchIncomes(Model.Description)">
+                                    <Icon Identifier="search" />
+                                    Find similar
+                                </a>
+                                <hr class="dropdown-divider" />
+                                <a class="dropdown-item" @onclick="@OnDelete">
+                                    <Icon Identifier="trash-alt" />
+                                    Delete
+                                </a>
+                            </div>
+                        </div>
+                    </ChildContent>
+                    <PlaceholderContent>
+                        <IconButton Icon="ellipsis-v" />
+                    </PlaceholderContent>
+                </Placeholder>
             </div>
         }
     </div>

--- a/src/Money.Blazor.Host/Components/IncomeCard.razor.cs
+++ b/src/Money.Blazor.Host/Components/IncomeCard.razor.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.Components;
+using Money.Models;
+using Money.Services;
+using Neptuo;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Money.Components;
+
+public partial class IncomeCard(Navigator Navigator)
+{
+    public interface IContext
+    {
+        bool HasEdit { get; }
+
+        void EditAmount(IncomeOverviewModel model);
+        void EditDescription(IncomeOverviewModel model);
+        void EditWhen(IncomeOverviewModel model);
+        void Delete(IncomeOverviewModel model);
+    }
+
+    [CascadingParameter]
+    public IContext Context { get; set; }
+
+    [Parameter]
+    public IncomeOverviewModel Model { get; set; }
+
+    [Parameter]
+    public string CssClass { get; set; }
+
+    protected void OnEditAmount()
+        => Context.EditAmount(Model);
+
+    protected void OnEditDescription()
+        => Context.EditDescription(Model);
+
+    protected void OnEditWhen()
+        => Context.EditWhen(Model);
+
+    protected void OnDelete()
+        => Context.Delete(Model);
+}

--- a/src/Money.Blazor.Host/Components/IncomeCardContext.razor
+++ b/src/Money.Blazor.Host/Components/IncomeCardContext.razor
@@ -1,0 +1,8 @@
+﻿<CascadingValue Value="@this">
+    @ChildContent
+</CascadingValue>
+
+<Confirm @ref="DeleteConfirm" Message="@DeleteMessage" OnConfirmed="@OnDeleteConfirmed" />
+<IncomeAmount @ref="AmountEditModal" IncomeKey="@SelectedItem?.Key" Amount="@SelectedItem?.Amount" />
+<IncomeDescription @ref="DescriptionEditModal" IncomeKey="@SelectedItem?.Key" Description="@SelectedItem?.Description" />
+<IncomeWhen @ref="WhenEditModal" IncomeKey="@SelectedItem?.Key" When="@(SelectedItem?.When ?? DateTime.MinValue)" />

--- a/src/Money.Blazor.Host/Components/IncomeCardContext.razor.cs
+++ b/src/Money.Blazor.Host/Components/IncomeCardContext.razor.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.AspNetCore.Components;
+using Money.Commands;
+using Money.Models;
+using Money.Services;
+using Neptuo.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Money.Components;
+
+public partial class IncomeCardContext(ICommandDispatcher Commands) : IncomeCard.IContext
+{
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+
+    [Parameter]
+    public bool IsEditEnabled { get; set; } = true;
+
+    #region IncomeCard.IContext
+
+    bool IncomeCard.IContext.HasEdit => IsEditEnabled;
+
+    void IncomeCard.IContext.EditAmount(IncomeOverviewModel model)
+        => OnActionClick(model, AmountEditModal);
+
+    void IncomeCard.IContext.EditDescription(IncomeOverviewModel model)
+        => OnActionClick(model, DescriptionEditModal);
+
+    void IncomeCard.IContext.EditWhen(IncomeOverviewModel model)
+        => OnActionClick(model, WhenEditModal);
+
+    void IncomeCard.IContext.Delete(IncomeOverviewModel model)
+        => OnDeleteClick(model);
+
+    #endregion
+
+    protected ModalDialog AmountEditModal { get; set; }
+    protected ModalDialog DescriptionEditModal { get; set; }
+    protected ModalDialog WhenEditModal { get; set; }
+
+    protected IncomeOverviewModel SelectedItem { get; set; }
+    protected string DeleteMessage { get; set; }
+    protected Confirm DeleteConfirm { get; set; }
+
+    protected void OnActionClick(IncomeOverviewModel model, ModalDialog modal)
+    {
+        SelectedItem = model;
+        modal.Show();
+        StateHasChanged();
+    }
+
+    protected void OnDeleteClick(IncomeOverviewModel model)
+    {
+        SelectedItem = model;
+        DeleteMessage = $"Do you really want to delete income '{model.Description}'?";
+        DeleteConfirm.Show();
+        StateHasChanged();
+    }
+
+    protected async void OnDeleteConfirmed()
+    {
+        await Commands.HandleAsync(new DeleteIncome(SelectedItem.Key));
+        StateHasChanged();
+    }
+}

--- a/src/Money.Blazor.Host/MockData.cs
+++ b/src/Money.Blazor.Host/MockData.cs
@@ -6,6 +6,13 @@ namespace Money;
 
 internal class MockData
 {
+    public static readonly IncomeOverviewModel IncomeOverviewModel = new IncomeOverviewModel(
+        KeyFactory.Create(typeof(Income)), 
+        new Price(1, "USD"), 
+        AppDateTime.Today, 
+        string.Empty
+    );
+
     public static readonly OutcomeOverviewModel ExpenseOverviewModel = new OutcomeOverviewModel(
         KeyFactory.Create(typeof(Outcome)), 
         new Price(1, "USD"), 
@@ -34,6 +41,9 @@ internal class MockData
 
     public static T Get<T>()
     {
+        if (typeof(T) == typeof(IncomeOverviewModel))
+            return (T)(object)IncomeOverviewModel;
+
         if (typeof(T) == typeof(OutcomeOverviewModel))
             return (T)(object)ExpenseOverviewModel;
 

--- a/src/Money.Blazor.Host/Pages/OverviewMonthIncome.razor
+++ b/src/Money.Blazor.Host/Pages/OverviewMonthIncome.razor
@@ -8,18 +8,7 @@
 </Title>
 <ExceptionPanel />
 
-@code
-{
-    IncomeAmount ChangeAmountModal;
-    IncomeDescription ChangeDescriptionModal;
-    IncomeWhen ChangeWhenModal;
-}
-
 <IncomeCreate @ref="CreateModal" />
-<IncomeAmount @ref="ChangeAmountModal" IncomeKey="@Selected?.Key" Amount="@Selected?.Amount" />
-<IncomeDescription @ref="ChangeDescriptionModal" IncomeKey="@Selected?.Key" Description="@Selected?.Description" />
-<IncomeWhen @ref="ChangeWhenModal" IncomeKey="@Selected?.Key" When="@(Selected?.When ?? AppDateTime.Today)" />
-<Confirm @ref="DeleteConfirm" Message="@DeleteMessage" OnConfirmed="@OnDeleteConfirmed" />
 
 <div class="container-narrow">
     <Loading Context="@Loading" IsOverlay="true">
@@ -46,47 +35,12 @@
             if (Items.Count > 0)
             {
                 <div class="cards">
-                    <CascadingValue Value="@this">
+                    <IncomeCardContext>
                         @foreach (var item in Items)
                         {
-                            <div class="row align-items-center border-bottom py-3">
-                                <div class="col-4 col-md-2 mb-2 mb-md-0">
-                                    <DateValue Value="item.When" />
-                                </div>
-                                <div class="col-8 col-md-3 text-md-end mb-2 mb-md-0 text-end">
-                                    <PriceView TagName="h3" CssClass="m-0" Value="item.Amount" />
-                                </div>
-                                <div class="col-md-1"></div>
-                                <div class="col mb-2 mb-md-0">
-                                    @item.Description
-                                </div>
-                                <div class="col-12 col-sm-auto controls text-end">
-                                    <div class="sort dropdown">
-                                        <IconButton Icon="ellipsis-v" data-bs-toggle="dropdown" />
-                                        <div class="dropdown-menu dropdown-menu-end">
-                                            <a class="dropdown-item" @onclick="@(() => Edit(item, ChangeAmountModal))">
-                                                <Icon Identifier="dollar-sign" />
-                                                Amount
-                                            </a>
-                                            <a class="dropdown-item" @onclick="@(() => Edit(item, ChangeDescriptionModal))">
-                                                <Icon Identifier="comment" />
-                                                Description
-                                            </a>
-                                            <a class="dropdown-item" @onclick="@(() => Edit(item, ChangeWhenModal))">
-                                                <Icon Identifier="calendar" />
-                                                When
-                                            </a>
-                                            <hr class="dropdown-divider" />
-                                            <a class="dropdown-item" @onclick="@(() => OnDeleteClick(item))">
-                                                <Icon Identifier="trash-alt" />
-                                                Delete
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            <IncomeCard Model="@item" />
                         }
-                    </CascadingValue>
+                    </IncomeCardContext>
                 </div>
 
                 <Paging Context="@PagingContext" />

--- a/src/Money.Blazor.Host/Pages/OverviewMonthIncome.razor.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewMonthIncome.razor.cs
@@ -20,7 +20,6 @@ using System.Threading.Tasks;
 namespace Money.Pages;
 
 public partial class OverviewMonthIncome(
-    ICommandDispatcher Commands,
     IEventHandlerCollection EventHandlers,
     IQueryDispatcher Queries,
     Interop Interop,
@@ -45,17 +44,12 @@ public partial class OverviewMonthIncome(
     protected MonthModel SelectedPeriod { get; set; }
 
     protected List<IncomeOverviewModel> Items { get; set; }
-    protected IncomeOverviewModel SelectedItem { get; set; }
 
     protected IncomeCreate CreateModal { get; set; }
 
     protected LoadingContext Loading { get; } = new LoadingContext();
     protected SortDescriptor<IncomeOverviewSortType> SortDescriptor { get; set; } = new(IncomeOverviewSortType.ByWhen, SortDirection.Descending);
     protected PagingContext PagingContext { get; set; }
-
-    protected IncomeOverviewModel Selected { get; set; }
-    protected string DeleteMessage { get; set; }
-    protected Confirm DeleteConfirm { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -101,34 +95,6 @@ public partial class OverviewMonthIncome(
     protected async void OnSortChanged()
     {
         await PagingContext.LoadAsync(0);
-        StateHasChanged();
-    }
-
-    protected void OnActionClick(IncomeOverviewModel model, ModalDialog modal)
-    {
-        SelectedItem = model;
-        modal.Show();
-        StateHasChanged();
-    }
-
-    protected void OnDeleteClick(IncomeOverviewModel model)
-    {
-        Selected = model;
-        DeleteMessage = $"Do you really want to delete income '{model.Description}'?";
-        DeleteConfirm.Show();
-        StateHasChanged();
-    }
-
-    protected void Edit(IncomeOverviewModel model, ModalDialog modal)
-    {
-        Selected = model;
-        modal.Show();
-        StateHasChanged();
-    }
-
-    protected async void OnDeleteConfirmed()
-    {
-        await Commands.HandleAsync(new DeleteIncome(Selected.Key));
         StateHasChanged();
     }
 

--- a/src/Money.Blazor.Host/Pages/Search.razor
+++ b/src/Money.Blazor.Host/Pages/Search.razor
@@ -5,6 +5,15 @@
 <ExceptionPanel />
 
 <div class="container-narrow">
+    <ul class="nav nav-pills mb-3">
+        <li>
+            <a class="nav-link active" href="@Navigator.UrlSearch(Query)">Expenses</a>
+        </li>
+        <li>
+            <a class="nav-link" href="@Navigator.UrlSearchIncomes(Query)">Incomes</a>
+        </li>
+    </ul>
+
     <form @onsubmit="@(() => { Navigator.OpenSearch(FormText, DefaultSort.Equals(FormSort) ? null : FormSort); StateHasChanged(); })">
         <div class="row g-2 mb-3">
             <div class="col">

--- a/src/Money.Blazor.Host/Pages/SearchIncomes.razor
+++ b/src/Money.Blazor.Host/Pages/SearchIncomes.razor
@@ -1,0 +1,40 @@
+﻿@page "/search/incomes"
+@attribute [Authorize]
+
+<Money.Components.Title Icon="search" Main="Search" Sub="Search for incomes" />
+<ExceptionPanel />
+
+<div class="container-narrow">
+    <form @onsubmit="@(() => { Navigator.OpenSearchIncomes(FormText, DefaultSort.Equals(FormSort) ? null : FormSort); StateHasChanged(); })">
+        <div class="row g-2 mb-3">
+            <div class="col">
+                <input @ref="SearchBox" class="form-control" placeholder="Search..." @bind="@FormText" />
+            </div>
+            <div class="col-auto">
+                <SortButton TType="@IncomeOverviewSortType" @bind-Current="@FormSort" />
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-primary d-block">
+                    <Icon Identifier="search" />
+                    <span class="d-none d-md-inline">
+                        Search
+                    </span>
+                </button>
+            </div>
+        </div>
+    </form>
+
+    <div class="cards">
+        <IncomeCardContext>
+            <AutoLoadListView 
+                Items="@Models" 
+                LoadingContext="@Loading" 
+                PagingContext="@PagingContext" 
+                NoDataMessage="@(string.IsNullOrEmpty(Query) ? "Type your query to start, use double quotes for exact match..." : "No matching income found.")" 
+                Context="item"
+            >
+                <IncomeCard Model="@item.Model" CssClass="@item.Placeholder?.CssClass" />
+            </AutoLoadListView>
+        </IncomeCardContext>
+    </div>
+</div>

--- a/src/Money.Blazor.Host/Pages/SearchIncomes.razor
+++ b/src/Money.Blazor.Host/Pages/SearchIncomes.razor
@@ -5,6 +5,15 @@
 <ExceptionPanel />
 
 <div class="container-narrow">
+    <ul class="nav nav-pills mb-3">
+        <li>
+            <a class="nav-link" href="@Navigator.UrlSearch(Query)">Expenses</a>
+        </li>
+        <li>
+            <a class="nav-link active" href="@Navigator.UrlSearchIncomes(Query)">Incomes</a>
+        </li>
+    </ul>
+
     <form @onsubmit="@(() => { Navigator.OpenSearchIncomes(FormText, DefaultSort.Equals(FormSort) ? null : FormSort); StateHasChanged(); })">
         <div class="row g-2 mb-3">
             <div class="col">

--- a/src/Money.Blazor.Host/Pages/SearchIncomes.razor
+++ b/src/Money.Blazor.Host/Pages/SearchIncomes.razor
@@ -39,6 +39,7 @@
                 Items="@Models" 
                 LoadingContext="@Loading" 
                 PagingContext="@PagingContext" 
+                PlaceholderCount="2"
                 NoDataMessage="@(string.IsNullOrEmpty(Query) ? "Type your query to start, use double quotes for exact match..." : "No matching income found.")" 
                 Context="item"
             >

--- a/src/Money.Blazor.Host/Pages/SearchIncomes.razor.cs
+++ b/src/Money.Blazor.Host/Pages/SearchIncomes.razor.cs
@@ -1,0 +1,222 @@
+﻿using Microsoft.AspNetCore.Components;
+using Money.Components;
+using Money.Events;
+using Money.Models;
+using Money.Models.Loading;
+using Money.Models.Queries;
+using Money.Models.Sorting;
+using Money.Queries;
+using Money.Services;
+using Neptuo.Events;
+using Neptuo.Events.Handlers;
+using Neptuo.Logging;
+using Neptuo.Queries;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Money.Pages;
+
+public partial class SearchIncomes(
+    Navigator Navigator,
+    IEventHandlerCollection EventHandlers,
+    IQueryDispatcher Queries,
+    ILog<SearchIncomes> Log
+) : 
+    System.IDisposable,
+    IEventHandler<IncomeCreated>,
+    IEventHandler<IncomeDeleted>,
+    IEventHandler<IncomeAmountChanged>,
+    IEventHandler<IncomeDescriptionChanged>,
+    IEventHandler<IncomeWhenChanged>,
+    IEventHandler<PulledToRefresh>
+{
+    [Parameter]
+    public string Query { get; set; }
+
+    protected ElementReference SearchBox { get; set; }
+
+    protected SortDescriptor<IncomeOverviewSortType> DefaultSort { get; set; }
+
+    protected LoadingContext Loading { get; } = new LoadingContext();
+    protected SortDescriptor<IncomeOverviewSortType> Sort { get; set; }
+    protected PagingContext PagingContext { get; set; }
+
+    protected List<IncomeOverviewModel> Models { get; set; } = [];
+    protected string FormText { get; set; }
+    protected SortDescriptor<IncomeOverviewSortType> FormSort { get; set; }
+
+    protected async override Task OnInitializedAsync()
+    {
+        DefaultSort = await Queries.QueryAsync(new GetSearchIncomesSortProperty());
+        FormSort = Sort = DefaultSort;
+        PagingContext = new PagingContext(LoadPageAsync, Loading);
+        Navigator.LocationChanged += OnLocationChanged;
+        BindEvents();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await base.OnParametersSetAsync();
+        await OnSearchAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (firstRender)
+            await SearchBox.FocusAsync();
+    }
+
+    public void Dispose()
+    {
+        Navigator.LocationChanged -= OnLocationChanged;
+        UnBindEvents();
+    }
+
+    private async void OnLocationChanged(string url)
+    {
+        await OnSearchAsync();
+        StateHasChanged();
+    }
+
+    protected async Task OnSearchAsync()
+    {
+        string lastQuery = Query;
+        var lastSort = Sort;
+        FormText = Query = Navigator.FindQueryParameter("q");
+
+        if (SortDescriptor.TryParseFromUrl<IncomeOverviewSortType>(Navigator.FindQueryParameter("sort"), out var descriptor))
+            FormSort = Sort = descriptor;
+        else
+            FormSort = Sort = DefaultSort;
+
+        Log.Debug($"Sort: last '{lastSort.Type}+{lastSort.Direction}', current '{Sort.Type}+{Sort.Direction}'.");
+
+        if (lastQuery == Query && lastSort.Equals(Sort))
+        {
+            Log.Debug("No change in query or sort.");
+            return;
+        }
+
+        Log.Debug($"Load first page with '{Query}' and '{Sort}'.");
+        await PagingContext.LoadAsync(0);
+    }
+
+    protected async Task<PagingLoadStatus> LoadPageAsync()
+    {
+        using (Loading.Start())
+        {
+            Log.Debug($"Starting to load {PagingContext.CurrentPageIndex}");
+            if (PagingContext.CurrentPageIndex == 0)
+            {
+                Models = [];
+                StateHasChanged();
+            }
+
+            if (!String.IsNullOrEmpty(FormText))
+            {
+                var models = await Queries.QueryAsync(Money.Models.Queries.SearchIncomes.Version1(FormText, Sort, PagingContext.CurrentPageIndex));
+                if (models.Count == 0)
+                {
+                    Log.Debug("Empty result");
+                    return PagingLoadStatus.EmptyPage;
+                }
+
+                Models.AddRange(models);
+
+                var result = models.Count == 10 ? PagingLoadStatus.HasNextPage : PagingLoadStatus.LastPage;
+                Log.Debug($"Loading finished, all items '{Models.Count}', result '{result}'");
+                StateHasChanged();
+                return result;
+            }
+            else
+            {
+                Log.Debug($"Empty query");
+                Models.Clear();
+                return PagingLoadStatus.LastPage;
+            }
+        }
+    }
+
+    protected IncomeOverviewModel FindModel(IEvent payload)
+        => Models.FirstOrDefault(o => o.Key.Equals(payload.AggregateKey));
+
+    #region Events
+
+    private void BindEvents()
+    {
+        EventHandlers
+            .Add<IncomeCreated>(this)
+            .Add<IncomeDeleted>(this)
+            .Add<IncomeAmountChanged>(this)
+            .Add<IncomeDescriptionChanged>(this)
+            .Add<IncomeWhenChanged>(this)
+            .Add<PulledToRefresh>(this);
+    }
+
+    private void UnBindEvents()
+    {
+        EventHandlers
+            .Remove<IncomeCreated>(this)
+            .Remove<IncomeDeleted>(this)
+            .Remove<IncomeAmountChanged>(this)
+            .Remove<IncomeDescriptionChanged>(this)
+            .Remove<IncomeWhenChanged>(this)
+            .Remove<PulledToRefresh>(this);
+    }
+
+    private Task UpdateModel(IEvent payload, Action<IncomeOverviewModel> handler)
+    {
+        IncomeOverviewModel model = FindModel(payload);
+        if (model != null)
+        {
+            handler(model);
+            StateHasChanged();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task ReloadDataAsync()
+    {
+        _ = PagingContext.LoadAsync(0).ContinueWith(_ => StateHasChanged());
+        return Task.CompletedTask;
+    }
+
+    Task IEventHandler<IncomeCreated>.HandleAsync(IncomeCreated payload)
+        => ReloadDataAsync();
+
+    Task IEventHandler<IncomeDeleted>.HandleAsync(IncomeDeleted payload)
+        => ReloadDataAsync();
+
+    Task IEventHandler<IncomeAmountChanged>.HandleAsync(IncomeAmountChanged payload)
+    {
+        if (Sort.Type == IncomeOverviewSortType.ByAmount)
+            return ReloadDataAsync();
+        else
+            return UpdateModel(payload, model => model.Amount = payload.NewValue);
+    }
+
+    Task IEventHandler<IncomeDescriptionChanged>.HandleAsync(IncomeDescriptionChanged payload)
+        => ReloadDataAsync();
+
+    Task IEventHandler<IncomeWhenChanged>.HandleAsync(IncomeWhenChanged payload)
+    {
+        if (Sort.Type == IncomeOverviewSortType.ByWhen)
+            return ReloadDataAsync();
+        else
+            return UpdateModel(payload, model => model.When = payload.When);
+    }
+
+    async Task IEventHandler<PulledToRefresh>.HandleAsync(PulledToRefresh payload)
+    {
+        payload.IsHandled = true;
+        await LoadPageAsync();
+        StateHasChanged();
+    }
+
+    #endregion
+}

--- a/src/Money.Blazor.Host/Pages/SearchIncomes.razor.cs
+++ b/src/Money.Blazor.Host/Pages/SearchIncomes.razor.cs
@@ -4,6 +4,7 @@ using Money.Events;
 using Money.Models;
 using Money.Models.Loading;
 using Money.Models.Queries;
+using SearchIncomesQuery = Money.Models.Queries.SearchIncomes;
 using Money.Models.Sorting;
 using Money.Queries;
 using Money.Services;
@@ -118,7 +119,7 @@ public partial class SearchIncomes(
 
             if (!String.IsNullOrEmpty(FormText))
             {
-                var models = await Queries.QueryAsync(Money.Models.Queries.SearchIncomes.Version1(FormText, Sort, PagingContext.CurrentPageIndex));
+                var models = await Queries.QueryAsync(SearchIncomesQuery.Version1(FormText, Sort, PagingContext.CurrentPageIndex));
                 if (models.Count == 0)
                 {
                     Log.Debug("Empty result");

--- a/src/Money.Blazor.Host/Pages/Users/Settings.razor
+++ b/src/Money.Blazor.Host/Pages/Users/Settings.razor
@@ -74,6 +74,10 @@
     <SortDescriptorEditor T="OutcomeOverviewSortType" @bind-Property="SearchSort.Property" @bind-Direction="SearchSort.Direction" />
 </PropertyDialog>
 
+<PropertyDialog @ref="SearchIncomesSortEditor" Model="@SearchIncomesSort" Title="Set search incomes sort">
+    <SortDescriptorEditor T="IncomeOverviewSortType" @bind-Property="SearchIncomesSort.Property" @bind-Direction="SearchIncomesSort.Direction" />
+</PropertyDialog>
+
 <PropertyDialog @ref="BalanceDisplayEditor" Model="@BalanceDisplay" Title="Set balance display">
     <EnumEditor T="BalanceDisplayType" @bind-Property="BalanceDisplay.Property" />
 </PropertyDialog>

--- a/src/Money.Blazor.Host/Pages/Users/Settings.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Users/Settings.razor.cs
@@ -46,6 +46,9 @@ public partial class Settings(
     protected SortPropertyViewModel<OutcomeOverviewSortType> SearchSort { get; set; }
     protected PropertyDialog SearchSortEditor { get; set; }
 
+    protected SortPropertyViewModel<IncomeOverviewSortType> SearchIncomesSort { get; set; }
+    protected PropertyDialog SearchIncomesSortEditor { get; set; }
+
     protected EnumPropertyViewModel<BalanceDisplayType> BalanceDisplay { get; set; }
     protected PropertyDialog BalanceDisplayEditor { get; set; }
 
@@ -80,6 +83,7 @@ public partial class Settings(
         SummaryDisplay = AddProperty<EnumPropertyViewModel<SummaryDisplayType>>("SummaryDisplay", "Summary display", () => SummaryDisplayEditor.Show(), icon: "eye", defaultValue: "Total");
         ExpenseOverviewSort = AddProperty<SortPropertyViewModel<OutcomeOverviewSortType>>("ExpenseOverviewSort", "Expense overview sort", () => ExpenseOverviewSortEditor.Show(), icon: "sort-alpha-down", defaultValue: "ByWhen-Descending");
         SearchSort = AddProperty<SortPropertyViewModel<OutcomeOverviewSortType>>("SearchSort", "Search sort", () => SearchSortEditor.Show(), icon: "sort-alpha-down", defaultValue: "ByWhen-Descending");
+        SearchIncomesSort = AddProperty<SortPropertyViewModel<IncomeOverviewSortType>>("SearchIncomesSort", "Search incomes sort", () => SearchIncomesSortEditor.Show(), icon: "sort-alpha-down", defaultValue: "ByWhen-Descending");
         BalanceDisplay = AddProperty<EnumPropertyViewModel<BalanceDisplayType>>("BalanceDisplay", "Balance display", () => BalanceDisplayEditor.Show(), icon: "eye", defaultValue: "Total");
         ExpenseTemplateSort = AddProperty<SortPropertyViewModel<ExpenseTemplateSortType>>("ExpenseTemplateSort", "ExpenseTemplate sort", () => ExpenseTemplateSortEditor.Show(), icon: "sort-alpha-down", defaultValue: "ByDescription-Ascending");
         ExpenseTemplateCalendarDisplay = AddProperty<EnumPropertyViewModel<ExpenseTemplateCalendarDisplayType>>("ExpenseTemplateCalendarDisplay", "Expense template calendar display", () => ExpenseTemplateCalendarDisplayEditor.Show(), icon: "eye", defaultValue: "Check");

--- a/src/Money.Blazor.Host/Queries/GetSearchIncomesSortProperty.cs
+++ b/src/Money.Blazor.Host/Queries/GetSearchIncomesSortProperty.cs
@@ -1,0 +1,18 @@
+using Money.Models;
+using Money.Models.Sorting;
+using Neptuo.Queries;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Money.Queries
+{
+    /// <summary>
+    /// A query for getting a sort descriptor for income search.
+    /// </summary>
+    public class GetSearchIncomesSortProperty : IQuery<SortDescriptor<IncomeOverviewSortType>>
+    { }
+}

--- a/src/Money.Blazor.Host/Services/Navigator.cs
+++ b/src/Money.Blazor.Host/Services/Navigator.cs
@@ -124,6 +124,9 @@ namespace Money.Services
         public void OpenSearch(string searchText = null, SortDescriptor<OutcomeOverviewSortType> sortDescriptor = null)
             => manager.NavigateTo(UrlSearch(searchText, sortDescriptor));
 
+        public void OpenSearchIncomes(string searchText = null, SortDescriptor<IncomeOverviewSortType> sortDescriptor = null)
+            => manager.NavigateTo(UrlSearchIncomes(searchText, sortDescriptor));
+
         public void OpenCategories()
             => manager.NavigateTo(UrlCategories());
 

--- a/src/Money.Blazor.Host/Services/NavigatorUrl.cs
+++ b/src/Money.Blazor.Host/Services/NavigatorUrl.cs
@@ -73,6 +73,18 @@ namespace Money.Services
             return url;
         }
 
+        public string UrlSearchIncomes(string query = null, SortDescriptor<IncomeOverviewSortType> sortDescriptor = null)
+        {
+            string url = "/search/incomes";
+            if (!String.IsNullOrEmpty(query))
+                url = QueryHelpers.AddQueryString(url, "q", query);
+
+            if (sortDescriptor != null)
+                url = QueryHelpers.AddQueryString(url, "sort", sortDescriptor.ToUrlString());
+
+            return url;
+        }
+
         public string UrlCategories()
             => "/categories";
 

--- a/src/Money.Blazor.Host/Services/UserPropertyQueryHandler.cs
+++ b/src/Money.Blazor.Host/Services/UserPropertyQueryHandler.cs
@@ -42,6 +42,10 @@ namespace Money.Services
             {
                 return await GetSortDescriptorAsync<OutcomeOverviewSortType>(dispatcher, "SearchSort", "ByWhen-Descending");
             }
+            else if (query is GetSearchIncomesSortProperty) 
+            {
+                return await GetSortDescriptorAsync<IncomeOverviewSortType>(dispatcher, "SearchIncomesSort", "ByWhen-Descending");
+            }
             else if (query is GetBalanceDisplayProperty) 
             {
                 return await GetEnumAsync<BalanceDisplayType>(dispatcher, "BalanceDisplay", "Total");

--- a/src/Money.Models.Builders/IncomeBuilder.cs
+++ b/src/Money.Models.Builders/IncomeBuilder.cs
@@ -156,7 +156,7 @@ namespace Money.Models.Builders
                     .WhereUserKey(query.UserKey);
 
                 var text = query.Text;
-                if (text.StartsWith("\"") && text.EndsWith("\""))
+                if (text.Length >= 2 && text.StartsWith("\"") && text.EndsWith("\""))
                 {
                     text = text.Substring(1, text.Length - 2);
                     sql = sql.Where(i => i.Description == text);

--- a/src/Money.Models.Builders/IncomeBuilder.cs
+++ b/src/Money.Models.Builders/IncomeBuilder.cs
@@ -23,7 +23,8 @@ namespace Money.Models.Builders
         IEventHandler<IncomeDeleted>,
         IQueryHandler<GetTotalMonthIncome, Price>,
         IQueryHandler<GetTotalYearIncome, Price>,
-        IQueryHandler<ListMonthIncome, List<IncomeOverviewModel>>
+        IQueryHandler<ListMonthIncome, List<IncomeOverviewModel>>,
+        IQueryHandler<SearchIncomes, List<IncomeOverviewModel>>
     {
         const int PageSize = 10;
 
@@ -140,8 +141,39 @@ namespace Money.Models.Builders
                 sql = ApplyPaging(sql, query);
 
                 List<IncomeOverviewModel> models = await sql
-                    .Select(i => i.ToOverviewModel(query))
+                    .Select(i => i.ToOverviewModel())
                     .ToListAsync();
+
+                return models;
+            }
+        }
+
+        public async Task<List<IncomeOverviewModel>> HandleAsync(SearchIncomes query)
+        {
+            using (ReadModelContext db = dbFactory.Create())
+            {
+                var sql = db.Incomes
+                    .WhereUserKey(query.UserKey);
+
+                var text = query.Text;
+                if (text.StartsWith("\"") && text.EndsWith("\""))
+                {
+                    text = text.Substring(1, text.Length - 2);
+                    sql = sql.Where(i => i.Description == text);
+                }
+                else
+                {
+                    sql = sql.Where(i => EF.Functions.Like(i.Description, $"%{text}%"));
+                }
+
+                sql = ApplySorting(sql, query);
+                sql = ApplyPaging(sql, query);
+
+                List<IncomeEntity> entities = await sql.ToListAsync();
+
+                List<IncomeOverviewModel> models = entities
+                    .Select(e => e.ToOverviewModel())
+                    .ToList();
 
                 return models;
             }

--- a/src/Money.Models.Builders/OutcomeBuilder.cs
+++ b/src/Money.Models.Builders/OutcomeBuilder.cs
@@ -490,7 +490,7 @@ namespace Money.Models.Builders
                     .WhereUserKey(query.UserKey);
 
                 var text = query.Text;
-                if (text.StartsWith("\"") && text.EndsWith("\""))
+                if (text.Length >= 2 && text.StartsWith("\"") && text.EndsWith("\""))
                 {
                     text = text.Substring(1, text.Length - 2);
                     sql = sql.Where(o => o.Description == text);

--- a/src/Money.Models.EntityFrameworkCore/IncomeEntity.cs
+++ b/src/Money.Models.EntityFrameworkCore/IncomeEntity.cs
@@ -35,7 +35,7 @@ namespace Money.Models
             When = payload.When;
         }
 
-        public IncomeOverviewModel ToOverviewModel(ListMonthIncome query) => new IncomeOverviewModel(
+        public IncomeOverviewModel ToOverviewModel() => new IncomeOverviewModel(
             GuidKey.Create(Id, KeyFactory.Empty(typeof(Income)).Type), 
             new Price(Amount, Currency), 
             When, 

--- a/src/Money.Models/Queries/SearchIncomes.cs
+++ b/src/Money.Models/Queries/SearchIncomes.cs
@@ -1,0 +1,66 @@
+﻿using Money.Models.Sorting;
+using Neptuo;
+using Neptuo.Formatters.Metadata;
+using Neptuo.Queries;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Money.Models.Queries
+{
+    /// <summary>
+    /// A query for searching in incomes.
+    /// </summary>
+    public class SearchIncomes : UserQuery, IQuery<List<IncomeOverviewModel>>, ISortableQuery<IncomeOverviewSortType>, IPageableQuery
+    {
+        /// <summary>
+        /// Gets a phrase to search.
+        /// </summary>
+        [CompositeProperty(0, Version = 1)]
+        public string Text { get; private set; }
+
+        /// <summary>
+        /// Gets a sorting descriptor.
+        /// </summary>
+        [CompositeProperty(1, Version = 1)]
+        public SortDescriptor<IncomeOverviewSortType> SortDescriptor { get; private set; }
+
+        /// <summary>
+        /// Gets a page index to load.
+        /// </summary>
+        [CompositeProperty(2, Version = 1)]
+        public int PageIndex { get; private set; }
+
+        [CompositeVersion]
+        [CompositeProperty(3, Version = 1)]
+        public int Version { get; private set; }
+
+        int? IPageableQuery.PageIndex => PageIndex;
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="text">A phrase to search.</param>
+        /// <param name="sortDescriptor">A sorting descriptor.</param>
+        /// <param name="pageIndex">A page index to load.</param>
+        [CompositeConstructor(Version = 1)]
+        public SearchIncomes(string text, SortDescriptor<IncomeOverviewSortType> sortDescriptor, int pageIndex, int version = 1)
+        {
+            Ensure.NotNullOrEmpty(text, "text");
+            Ensure.NotNull(sortDescriptor, "sortDescriptor");
+            Ensure.PositiveOrZero(pageIndex, "pageIndex");
+            Text = text.Trim();
+            SortDescriptor = sortDescriptor;
+            PageIndex = pageIndex;
+
+            Version = version;
+        }
+
+        public static SearchIncomes Version1(string text, SortDescriptor<IncomeOverviewSortType> sortDescriptor, int pageIndex)
+        {
+            return new SearchIncomes(text, sortDescriptor, pageIndex, 1);
+        }
+    }
+}


### PR DESCRIPTION
Add full support for searching incomes, mirroring the existing expense search functionality.

## API changes
- New `SearchIncomes` query model with text search (exact match with quotes + LIKE pattern)
- New `HandleAsync(SearchIncomes)` handler in `IncomeBuilder` with sorting and pagination
- New `POST /api/queries/search-incomes` endpoint via `QueryMapper`

## Blazor client changes
- **New `IncomeCard` component** — Extracted reusable card from `OverviewMonthIncome` inline rendering
- **New `IncomeCardContext` component** — Manages edit/delete modals for `IncomeCard`
- **New `SearchIncomes` page** at `/search/incomes` — Full search UI with text input, sort button, infinite scroll
- **Refactored `OverviewMonthIncome`** to use `IncomeCard`/`IncomeCardContext` instead of inline rendering
- New `GetSearchIncomesSortProperty` query for persisted user sort preferences
- Navigator URL/Open helpers for `/search/incomes`

Closes #611
Closes #643
Closes #644