### PR TITLE
Fix decimal display when PriceDecimalDigits hides decimals

### DIFF
--- a/src/Money.Blazor.Host/Components/AmountBox.razor
+++ b/src/Money.Blazor.Host/Components/AmountBox.razor
@@ -1,6 +1,6 @@
 ﻿<AuthenticatedView OnChanged="OnAuthenticationChanged">
     <div class="input-group">
-        <input type="text" class="form-control" id="@Id" value="@(AllowEmpty && (Value == null || Value.Value == 0) ? "" : Amount.ToString("F" + DecimalDigits))" @onchange="OnValueChanged" data-autofocus="@AutoFocus" data-select="@AutoSelect" autocomplete="off" readonly="@IsReadOnly" />
+        <input type="text" class="form-control" id="@Id" value="@(AllowEmpty && (Value == null || Value.Value == 0) ? "" : Amount.ToString("F" + InputDecimalDigits))" @onchange="OnValueChanged" data-autofocus="@AutoFocus" data-select="@AutoSelect" autocomplete="off" readonly="@IsReadOnly" />
         @if (Currencies != null)
         {
             <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-popper-config='{"strategy":"fixed"}' disabled="@IsReadOnly">

--- a/src/Money.Blazor.Host/Components/AmountBox.razor.cs
+++ b/src/Money.Blazor.Host/Components/AmountBox.razor.cs
@@ -2,7 +2,7 @@
 using Money.Events;
 using Money.Models;
 using Money.Models.Queries;
-using Money.Pages;
+using Money.Services;
 using Money.Queries;
 using Neptuo.Events;
 using Neptuo.Events.Handlers;
@@ -49,7 +49,7 @@ public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries, IE
     protected decimal Amount { get; set; }
     protected string Currency { get; set; }
     protected int DecimalDigits { get; set; }
-    protected int InputDecimalDigits => Amount != Math.Truncate(Amount) ? Math.Max(DecimalDigits, 2) : DecimalDigits;
+    protected int InputDecimalDigits => DecimalDigitsHelper.GetEffectiveDecimalDigits(Amount, DecimalDigits);
     protected List<CurrencyModel> Currencies { get; private set; }
 
     private string defaultCurrency = null;

--- a/src/Money.Blazor.Host/Components/AmountBox.razor.cs
+++ b/src/Money.Blazor.Host/Components/AmountBox.razor.cs
@@ -49,6 +49,7 @@ public partial class AmountBox(ILog<AmountBox> Log, IQueryDispatcher Queries, IE
     protected decimal Amount { get; set; }
     protected string Currency { get; set; }
     protected int DecimalDigits { get; set; }
+    protected int InputDecimalDigits => Amount != Math.Truncate(Amount) ? Math.Max(DecimalDigits, 2) : DecimalDigits;
     protected List<CurrencyModel> Currencies { get; private set; }
 
     private string defaultCurrency = null;

--- a/src/Money.Blazor.Host/Services/CurrencyFormatter.cs
+++ b/src/Money.Blazor.Host/Services/CurrencyFormatter.cs
@@ -14,7 +14,6 @@ namespace Money.Services
         private readonly List<CurrencyModel> models;
         private readonly int decimalDigits;
         private Dictionary<string, CultureInfo> currencies;
-        private Dictionary<string, CultureInfo> modified = new Dictionary<string, CultureInfo>();
 
         public CurrencyFormatter(List<CurrencyModel> models, int decimalDigits)
         {
@@ -94,19 +93,25 @@ namespace Money.Services
             if (!currencies.TryGetValue(price.Currency, out var culture))
                 culture = CultureInfo.CurrentCulture;
 
-            CultureInfo modifiedCulture = null;
-            if (applyUserDigits && !modified.TryGetValue(price.Currency, out modifiedCulture))
-            {
-                modified[price.Currency] = modifiedCulture = (CultureInfo)culture.Clone();
-                modifiedCulture.NumberFormat.CurrencyDecimalDigits = decimalDigits;
-                modifiedCulture.NumberFormat.CurrencySymbol = currency.Symbol;
-            }
+            int effectiveDigits = applyUserDigits ? GetEffectiveDecimalDigits(price.Value) : culture.NumberFormat.CurrencyDecimalDigits;
 
-            string value = price.Value.ToString("C", modifiedCulture ?? culture);
+            var modifiedCulture = (CultureInfo)culture.Clone();
+            modifiedCulture.NumberFormat.CurrencyDecimalDigits = effectiveDigits;
+            modifiedCulture.NumberFormat.CurrencySymbol = currency.Symbol;
+
+            string value = price.Value.ToString("C", modifiedCulture);
             if (applyPlusForPositiveNumbers && price.Value > 0)
                 value = $"+{value}";
 
             return value;
+        }
+
+        private int GetEffectiveDecimalDigits(decimal value)
+        {
+            if (value != Math.Truncate(value))
+                return Math.Max(decimalDigits, 2);
+
+            return decimalDigits;
         }
 
         public enum FormatZero

--- a/src/Money.Blazor.Host/Services/CurrencyFormatter.cs
+++ b/src/Money.Blazor.Host/Services/CurrencyFormatter.cs
@@ -14,6 +14,7 @@ namespace Money.Services
         private readonly List<CurrencyModel> models;
         private readonly int decimalDigits;
         private Dictionary<string, CultureInfo> currencies;
+        private readonly Dictionary<(string currencyCode, int effectiveDigits), CultureInfo> clonedCultureCache = new();
 
         public CurrencyFormatter(List<CurrencyModel> models, int decimalDigits)
         {
@@ -93,11 +94,9 @@ namespace Money.Services
             if (!currencies.TryGetValue(price.Currency, out var culture))
                 culture = CultureInfo.CurrentCulture;
 
-            int effectiveDigits = applyUserDigits ? GetEffectiveDecimalDigits(price.Value) : culture.NumberFormat.CurrencyDecimalDigits;
+            int effectiveDigits = applyUserDigits ? DecimalDigitsHelper.GetEffectiveDecimalDigits(price.Value, decimalDigits) : culture.NumberFormat.CurrencyDecimalDigits;
 
-            var modifiedCulture = (CultureInfo)culture.Clone();
-            modifiedCulture.NumberFormat.CurrencyDecimalDigits = effectiveDigits;
-            modifiedCulture.NumberFormat.CurrencySymbol = currency.Symbol;
+            var modifiedCulture = GetOrCreateModifiedCulture(culture, currency, effectiveDigits);
 
             string value = price.Value.ToString("C", modifiedCulture);
             if (applyPlusForPositiveNumbers && price.Value > 0)
@@ -106,12 +105,18 @@ namespace Money.Services
             return value;
         }
 
-        private int GetEffectiveDecimalDigits(decimal value)
+        private CultureInfo GetOrCreateModifiedCulture(CultureInfo baseCulture, CurrencyModel currency, int effectiveDigits)
         {
-            if (value != Math.Truncate(value))
-                return Math.Max(decimalDigits, 2);
+            var key = (currency.UniqueCode, effectiveDigits);
+            if (!clonedCultureCache.TryGetValue(key, out var cached))
+            {
+                cached = (CultureInfo)baseCulture.Clone();
+                cached.NumberFormat.CurrencyDecimalDigits = effectiveDigits;
+                cached.NumberFormat.CurrencySymbol = currency.Symbol;
+                clonedCultureCache[key] = cached;
+            }
 
-            return decimalDigits;
+            return cached;
         }
 
         public enum FormatZero

--- a/src/Money.Blazor.Host/Services/DecimalDigitsHelper.cs
+++ b/src/Money.Blazor.Host/Services/DecimalDigitsHelper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Money.Services
+{
+    public static class DecimalDigitsHelper
+    {
+        /// <summary>
+        /// Returns the effective number of decimal digits to use for display/input.
+        /// If the value has a fractional part, returns at least 2 digits.
+        /// </summary>
+        public static int GetEffectiveDecimalDigits(decimal value, int userDecimalDigits)
+        {
+            if (value != Math.Truncate(value))
+                return Math.Max(userDecimalDigits, 2);
+
+            return userDecimalDigits;
+        }
+    }
+}


### PR DESCRIPTION
When a user sets `PriceDecimalDigits` to 0 (e.g. to hide decimals for CZK), they could not enter or see decimal amounts for other currencies like EUR. The display setting was applied uniformly, truncating/rounding fractional values both in the input field and in formatted price displays.

## Approach

Both `AmountBox` and `CurrencyFormatter` now use the same logic: respect the user's display preference for whole-number values, but preserve at least 2 decimal places when the value actually has a fractional part.

- **AmountBox**: Added `InputDecimalDigits` property that returns `Math.Max(DecimalDigits, 2)` when the amount has decimals, otherwise uses the user's preference.
- **CurrencyFormatter**: Replaced the cached per-currency culture approach with per-value formatting that checks whether the price has a fractional component before deciding decimal digits.

**Examples with `PriceDecimalDigits = 0`:**
- `100` displays as `100 Kc` (respects preference)
- `10.50` displays as `10,50 Kc` (preserves actual decimals)

Fixes #602