### PR TITLE
Fix CORS headers missing on 500 error responses

### DIFF
--- a/src/Money.Api/Startup.cs
+++ b/src/Money.Api/Startup.cs
@@ -149,16 +149,6 @@ namespace Money
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-            else
-            {
-                app.UseStatusCodePages();
-                app.UseErrorHandler();
-            }
-
             app.UseRouting();
 
             app.UseCors(p =>
@@ -174,6 +164,16 @@ namespace Money
                 p.SetPreflightMaxAge(TimeSpan.FromMinutes(10));
                 p.WithExposedHeaders(VersionHeader.Name, RenewalTokenHeader.Name);
             });
+
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseStatusCodePages();
+                app.UseErrorHandler();
+            }
 
             app.UseAuthentication();
             app.UseAuthorization();


### PR DESCRIPTION
When the API returns an unhandled 500 error, the response lacks CORS headers because the error handling middleware (`UseStatusCodePages` + `UseErrorHandler`) was positioned before `UseCors()` in the pipeline. The browser then blocks the response as a CORS violation, and the client misinterprets it as "server not responding" rather than a proper server error -- leading to a state where SignalR shows "connected" but all HTTP queries silently fail.

**Fix:** Reorder the middleware pipeline in `Startup.cs` so that error handling runs after `UseCors()`. This ensures any 500 response is generated inside the CORS middleware, and the browser receives proper CORS headers along with the error status code. The client can then handle it as an `InternalServerException` and display it in the ExceptionPanel.

Fixes #615