### PR TITLE
Fix overview adding expenses from wrong category to filtered list

### DIFF
--- a/src/Money.Blazor.Host/Pages/Overview.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Overview.razor.cs
@@ -261,6 +261,9 @@ public partial class Overview<T>(
 
     Task IEventHandler<OutcomeCreated>.HandleAsync(OutcomeCreated payload)
     {
+        if (!CategoryKey.IsEmpty && !CategoryKey.Equals(payload.CategoryKey))
+            return Task.CompletedTask;
+
         if (IsContained(payload.When))
         {
             if (PagingContext.HasNextPage)


### PR DESCRIPTION
When the Overview page is filtered by a specific category, creating or duplicating an expense in a *different* category incorrectly adds it to the visible list. The `OutcomeCreated` event handler only checked whether the expense date fell within the selected period, but never verified the category.

This adds an early-return guard in the handler: if a category filter is active (`CategoryKey` is not empty), the event is ignored when the new expense's category doesn't match.

Fixes #605