### PR TITLE
Fix expense template date overflow for short months

### DIFF
--- a/src/Money.Models.Builders/OutcomeBuilder.cs
+++ b/src/Money.Models.Builders/OutcomeBuilder.cs
@@ -783,9 +783,9 @@ namespace Money.Models.Builders
                         ? expense.ToExpenseChecklistModel(template.GetKey())
                         : template.ToExpenseChecklistModel(template.Period switch
                         {
-                            RecurrencePeriod.Monthly => new DateTime(query.Month.Year, query.Month.Month, template.DayInPeriod.Value),
-                            RecurrencePeriod.Yearly => new DateTime(query.Month.Year, template.MonthInPeriod.Value, template.DayInPeriod.Value),
-                            RecurrencePeriod.XMonths => new DateTime(query.Month.Year, query.Month.Month, template.DayInPeriod.Value),
+                            RecurrencePeriod.Monthly => new DateTime(query.Month.Year, query.Month.Month, Math.Min(template.DayInPeriod.Value, DateTime.DaysInMonth(query.Month.Year, query.Month.Month))),
+                            RecurrencePeriod.Yearly => new DateTime(query.Month.Year, template.MonthInPeriod.Value, Math.Min(template.DayInPeriod.Value, DateTime.DaysInMonth(query.Month.Year, template.MonthInPeriod.Value))),
+                            RecurrencePeriod.XMonths => new DateTime(query.Month.Year, query.Month.Month, Math.Min(template.DayInPeriod.Value, DateTime.DaysInMonth(query.Month.Year, query.Month.Month))),
                             RecurrencePeriod.Single => template.DueDate.Value,
                             _ => throw Ensure.Exception.NotSupported($"The value '{template.Period}' is not supported.")
                         });


### PR DESCRIPTION
When an expense template has `DayInPeriod` set to 29, 30, or 31, querying the checklist for a shorter month (e.g., February) throws `ArgumentOutOfRangeException` because `new DateTime(year, month, day)` rejects invalid day values.

This clamps the day to the actual number of days in the target month using `Math.Min(template.DayInPeriod.Value, DateTime.DaysInMonth(year, month))`. A template set to the 31st will now safely resolve to Feb 28 (or 29 in a leap year), Apr 30, etc.

The fix applies to all three affected recurrence types: Monthly, Yearly, and XMonths.

Fixes #614