### PR TITLE
Fix search nav order to match overview (Incomes, Expenses)

### DIFF
--- a/src/Money.Blazor.Host/Pages/Search.razor
+++ b/src/Money.Blazor.Host/Pages/Search.razor
@@ -7,10 +7,10 @@
 <div class="container-narrow">
     <ul class="nav nav-pills mb-3">
         <li>
-            <a class="nav-link active" href="@Navigator.UrlSearch(Query)">Expenses</a>
+            <a class="nav-link" href="@Navigator.UrlSearchIncomes(Query)">Incomes</a>
         </li>
         <li>
-            <a class="nav-link" href="@Navigator.UrlSearchIncomes(Query)">Incomes</a>
+            <a class="nav-link active" href="@Navigator.UrlSearch(Query)">Expenses</a>
         </li>
     </ul>
 

--- a/src/Money.Blazor.Host/Pages/SearchIncomes.razor
+++ b/src/Money.Blazor.Host/Pages/SearchIncomes.razor
@@ -7,10 +7,10 @@
 <div class="container-narrow">
     <ul class="nav nav-pills mb-3">
         <li>
-            <a class="nav-link" href="@Navigator.UrlSearch(Query)">Expenses</a>
+            <a class="nav-link active" href="@Navigator.UrlSearchIncomes(Query)">Incomes</a>
         </li>
         <li>
-            <a class="nav-link active" href="@Navigator.UrlSearchIncomes(Query)">Incomes</a>
+            <a class="nav-link" href="@Navigator.UrlSearch(Query)">Expenses</a>
         </li>
     </ul>
 


### PR DESCRIPTION
The Overview page shows nav links in "Incomes, Expenses" order, but the Search and SearchIncomes pages had them reversed ("Expenses, Incomes"). This swaps the nav pill order in both search pages to be consistent with the overview.