### PR TITLE
Add PeriodSelector to Overview, OverviewIncome, and ExpenseChecklist pages

### DIFF
--- a/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
+++ b/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
@@ -5,14 +5,14 @@
 <ExceptionPanel />
 
 <div class="container-narrow">
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex align-items-center mb-3">
         <div>
             <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetMonthsAsync" LinkFactory="@(month => Navigator.UrlChecklist(month))" />
             <span class="ps-2">
                 <Loading Context="@Loading" />
             </span>
         </div>
-        <ul class="nav nav-pills">
+        <ul class="nav nav-pills ps-3">
             <li>
                 <a class="nav-link" href="@Navigator.UrlOverviewIncomes(SelectedPeriod)">Incomes</a>
             </li>

--- a/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
+++ b/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
@@ -5,6 +5,15 @@
 <ExceptionPanel />
 
 <div class="container-narrow">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetMonthsAsync" LinkFactory="@(month => Navigator.UrlChecklist(month))" />
+            <span class="ps-2">
+                <Loading Context="@Loading" />
+            </span>
+        </div>
+    </div>
+
     <ul class="nav nav-pills mb-3">
         <li>
             <a class="nav-link" href="@Navigator.UrlOverviewIncomes(SelectedPeriod)">Incomes</a>

--- a/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
+++ b/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
@@ -12,19 +12,18 @@
                 <Loading Context="@Loading" />
             </span>
         </div>
+        <ul class="nav nav-pills">
+            <li>
+                <a class="nav-link" href="@Navigator.UrlOverviewIncomes(SelectedPeriod)">Incomes</a>
+            </li>
+            <li>
+                <a class="nav-link" href="@Navigator.UrlOverview(SelectedPeriod)">Expenses</a>
+            </li>
+            <li>
+                <a class="nav-link active" href="@Navigator.UrlChecklist(SelectedPeriod)">Checklist</a>
+            </li>
+        </ul>
     </div>
-
-    <ul class="nav nav-pills mb-3">
-        <li>
-            <a class="nav-link" href="@Navigator.UrlOverviewIncomes(SelectedPeriod)">Incomes</a>
-        </li>
-        <li>
-            <a class="nav-link" href="@Navigator.UrlOverview(SelectedPeriod)">Expenses</a>
-        </li>
-        <li>
-            <a class="nav-link active" href="@Navigator.UrlChecklist(SelectedPeriod)">Checklist</a>
-        </li>
-    </ul>
 
     <Loading Context="@Loading">
         @if (Models.Count == 0)

--- a/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor.cs
@@ -36,6 +36,7 @@ public partial class ExpenseChecklistMonth(
     public int Month { get; set; }
 
     protected MonthModel SelectedPeriod { get; set; }
+    protected IReadOnlyCollection<MonthModel> PeriodGuesses { get; set; }
     protected List<ExpenseChecklistModel> Models { get; set; } = new();
     protected LoadingContext Loading { get; set; } = new();
 
@@ -62,8 +63,14 @@ public partial class ExpenseChecklistMonth(
     private void EnsureSelectedPeriod()
     {
         if (SelectedPeriod == null)
+        {
             SelectedPeriod = new MonthModel(Year, Month);
+            PeriodGuesses = new MonthModel[] { SelectedPeriod - 1, SelectedPeriod - 2 };
+        }
     }
+
+    protected async Task<IReadOnlyCollection<MonthModel>> GetMonthsAsync()
+        => await Queries.QueryAsync(new ListMonthWithExpenseOrIncome());
 
     private async Task LoadDataAsync()
     {

--- a/src/Money.Blazor.Host/Pages/Overview.razor
+++ b/src/Money.Blazor.Host/Pages/Overview.razor
@@ -20,6 +20,12 @@
 <ExceptionPanel />
 
 <div class="container-narrow">
+    @{
+        var incomeUrl = ListIncomeUrl();
+        var checklistUrl = ChecklistUrl();
+        var trendsUrl = TrendsSelectedPeriodUrl();
+    }
+
     <div class="d-flex justify-content-between align-items-center mb-3">
         <div>
             <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetPeriodsAsync" LinkFactory="UrlOverview" />
@@ -27,39 +33,33 @@
                 <Loading Context="@Loading" />
             </span>
         </div>
+        @if (incomeUrl != null || trendsUrl != null)
+        {
+            <ul class="nav nav-pills">
+                @if (incomeUrl != null)
+                {
+                    <li>
+                        <a class="nav-link" href="@incomeUrl">Incomes</a>
+                    </li>
+                }
+                <li>
+                    <a class="nav-link active" href="@Navigator.UrlCurrent()">Expenses</a>
+                </li>
+                @if (checklistUrl != null)
+                {
+                    <li>
+                        <a class="nav-link" href="@checklistUrl">Checklist</a>
+                    </li>
+                }
+                @if (trendsUrl != null)
+                {
+                    <li>
+                        <a class="nav-link" href="@trendsUrl">Trends</a>
+                    </li>
+                }
+            </ul>
+        }
     </div>
-
-    @{
-        var incomeUrl = ListIncomeUrl();
-        var checklistUrl = ChecklistUrl();
-        var trendsUrl = TrendsSelectedPeriodUrl();
-    }
-    @if (incomeUrl != null || trendsUrl != null)
-    {
-        <ul class="nav nav-pills float-start">
-            @if (incomeUrl != null)
-            {
-                <li>
-                    <a class="nav-link" href="@incomeUrl">Incomes</a>
-                </li>
-            }
-            <li>
-                <a class="nav-link active" href="@Navigator.UrlCurrent()">Expenses</a>
-            </li>
-            @if (checklistUrl != null)
-            {
-                <li>
-                    <a class="nav-link" href="@checklistUrl">Checklist</a>
-                </li>
-            }
-            @if (trendsUrl != null)
-            {
-                <li>
-                    <a class="nav-link" href="@trendsUrl">Trends</a>
-                </li>
-            }
-        </ul>
-    }
 
     @if (Items?.Count > 0)
     {

--- a/src/Money.Blazor.Host/Pages/Overview.razor
+++ b/src/Money.Blazor.Host/Pages/Overview.razor
@@ -33,39 +33,41 @@
                 <Loading Context="@Loading" />
             </span>
         </div>
-        @if (incomeUrl != null || trendsUrl != null)
-        {
-            <ul class="nav nav-pills">
-                @if (incomeUrl != null)
-                {
+        <div class="d-flex align-items-center">
+            @if (incomeUrl != null || trendsUrl != null)
+            {
+                <ul class="nav nav-pills">
+                    @if (incomeUrl != null)
+                    {
+                        <li>
+                            <a class="nav-link" href="@incomeUrl">Incomes</a>
+                        </li>
+                    }
                     <li>
-                        <a class="nav-link" href="@incomeUrl">Incomes</a>
+                        <a class="nav-link active" href="@Navigator.UrlCurrent()">Expenses</a>
                     </li>
-                }
-                <li>
-                    <a class="nav-link active" href="@Navigator.UrlCurrent()">Expenses</a>
-                </li>
-                @if (checklistUrl != null)
-                {
-                    <li>
-                        <a class="nav-link" href="@checklistUrl">Checklist</a>
-                    </li>
-                }
-                @if (trendsUrl != null)
-                {
-                    <li>
-                        <a class="nav-link" href="@trendsUrl">Trends</a>
-                    </li>
-                }
-            </ul>
-        }
+                    @if (checklistUrl != null)
+                    {
+                        <li>
+                            <a class="nav-link" href="@checklistUrl">Checklist</a>
+                        </li>
+                    }
+                    @if (trendsUrl != null)
+                    {
+                        <li>
+                            <a class="nav-link" href="@trendsUrl">Trends</a>
+                        </li>
+                    }
+                </ul>
+            }
+            @if (Items?.Count > 0)
+            {
+                <span class="ps-2">
+                    <SortButton TType="@OutcomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
+                </span>
+            }
+        </div>
     </div>
-
-    @if (Items?.Count > 0)
-    {
-        <SortButton TType="@OutcomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
-    }
-    <div class="clear"></div>
 
     <div class="cards">
         <ExpenseCardContext>

--- a/src/Money.Blazor.Host/Pages/Overview.razor
+++ b/src/Money.Blazor.Host/Pages/Overview.razor
@@ -26,47 +26,45 @@
         var trendsUrl = TrendsSelectedPeriodUrl();
     }
 
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex align-items-center mb-3">
         <div>
             <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetPeriodsAsync" LinkFactory="UrlOverview" />
             <span class="ps-2">
                 <Loading Context="@Loading" />
             </span>
         </div>
-        <div class="d-flex align-items-center">
-            @if (incomeUrl != null || trendsUrl != null)
-            {
-                <ul class="nav nav-pills">
-                    @if (incomeUrl != null)
-                    {
-                        <li>
-                            <a class="nav-link" href="@incomeUrl">Incomes</a>
-                        </li>
-                    }
+        @if (incomeUrl != null || trendsUrl != null)
+        {
+            <ul class="nav nav-pills ps-3">
+                @if (incomeUrl != null)
+                {
                     <li>
-                        <a class="nav-link active" href="@Navigator.UrlCurrent()">Expenses</a>
+                        <a class="nav-link" href="@incomeUrl">Incomes</a>
                     </li>
-                    @if (checklistUrl != null)
-                    {
-                        <li>
-                            <a class="nav-link" href="@checklistUrl">Checklist</a>
-                        </li>
-                    }
-                    @if (trendsUrl != null)
-                    {
-                        <li>
-                            <a class="nav-link" href="@trendsUrl">Trends</a>
-                        </li>
-                    }
-                </ul>
-            }
-            @if (Items?.Count > 0)
-            {
-                <span class="ps-2">
-                    <SortButton TType="@OutcomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
-                </span>
-            }
-        </div>
+                }
+                <li>
+                    <a class="nav-link active" href="@Navigator.UrlCurrent()">Expenses</a>
+                </li>
+                @if (checklistUrl != null)
+                {
+                    <li>
+                        <a class="nav-link" href="@checklistUrl">Checklist</a>
+                    </li>
+                }
+                @if (trendsUrl != null)
+                {
+                    <li>
+                        <a class="nav-link" href="@trendsUrl">Trends</a>
+                    </li>
+                }
+            </ul>
+        }
+        @if (Items?.Count > 0)
+        {
+            <span class="ms-auto">
+                <SortButton TType="@OutcomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
+            </span>
+        }
     </div>
 
     <div class="cards">

--- a/src/Money.Blazor.Host/Pages/Overview.razor
+++ b/src/Money.Blazor.Host/Pages/Overview.razor
@@ -20,6 +20,15 @@
 <ExceptionPanel />
 
 <div class="container-narrow">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetPeriodsAsync" LinkFactory="UrlOverview" />
+            <span class="ps-2">
+                <Loading Context="@Loading" />
+            </span>
+        </div>
+    </div>
+
     @{
         var incomeUrl = ListIncomeUrl();
         var checklistUrl = ChecklistUrl();

--- a/src/Money.Blazor.Host/Pages/Overview.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Overview.razor.cs
@@ -45,6 +45,7 @@ public partial class Overview<T>(
     protected string SubTitle { get; set; } = subTitle;
 
     protected T SelectedPeriod { get; set; }
+    protected IReadOnlyCollection<T> PeriodGuesses { get; set; }
     protected IKey CategoryKey { get; set; }
     protected string CategoryName { get; set; }
     protected List<OutcomeOverviewModel> Items { get; set; }
@@ -73,6 +74,7 @@ public partial class Overview<T>(
     {
         CategoryKey = CreateSelectedCategoryFromParameters();
         SelectedPeriod = CreateSelectedItemFromParameters();
+        PeriodGuesses = CreatePeriodGuesses();
 
         if (!CategoryKey.IsEmpty)
         {
@@ -95,6 +97,9 @@ public partial class Overview<T>(
 
     protected virtual T CreateSelectedItemFromParameters()
         => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(CreateSelectedItemFromParameters)}'.");
+
+    protected virtual IReadOnlyCollection<T> CreatePeriodGuesses()
+        => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(CreatePeriodGuesses)}'.");
 
     protected virtual string ListIncomeUrl()
         => null;
@@ -151,6 +156,15 @@ public partial class Overview<T>(
 
     protected virtual IQuery<List<OutcomeOverviewModel>> CreateItemsQuery(int pageIndex)
         => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(CreateItemsQuery)}'.");
+
+    protected virtual IQuery<List<T>> CreatePeriodsQuery()
+        => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(CreatePeriodsQuery)}'.");
+
+    protected async Task<IReadOnlyCollection<T>> GetPeriodsAsync()
+        => await Queries.QueryAsync(CreatePeriodsQuery());
+
+    protected virtual string UrlOverview(T period)
+        => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(UrlOverview)}'.");
 
     protected async void OnSortChanged()
     {

--- a/src/Money.Blazor.Host/Pages/OverviewIncome.razor
+++ b/src/Money.Blazor.Host/Pages/OverviewIncome.razor
@@ -10,38 +10,36 @@
 <IncomeCreate @ref="CreateModal" />
 
 <div class="container-narrow">
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex align-items-center mb-3">
         <div>
             <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetPeriodsAsync" LinkFactory="UrlOverviewIncomes" />
             <span class="ps-2">
                 <Loading Context="@Loading" IsOverlay="true" />
             </span>
         </div>
-        <div class="d-flex align-items-center">
-            <ul class="nav nav-pills">
-                <li>
-                    <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
-                </li>
-                <li>
-                    <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
-                </li>
-                @{
-                    var checklistUrl = ChecklistUrl();
-                }
-                @if (checklistUrl != null)
-                {
-                    <li>
-                        <a class="nav-link" href="@checklistUrl">Checklist</a>
-                    </li>
-                }
-            </ul>
-            @if (Items?.Count > 0)
-            {
-                <span class="ps-2">
-                    <SortButton TType="@IncomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
-                </span>
+        <ul class="nav nav-pills ps-3">
+            <li>
+                <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
+            </li>
+            <li>
+                <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
+            </li>
+            @{
+                var checklistUrl = ChecklistUrl();
             }
-        </div>
+            @if (checklistUrl != null)
+            {
+                <li>
+                    <a class="nav-link" href="@checklistUrl">Checklist</a>
+                </li>
+            }
+        </ul>
+        @if (Items?.Count > 0)
+        {
+            <span class="ms-auto">
+                <SortButton TType="@IncomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
+            </span>
+        }
     </div>
 
     @if (Items != null)

--- a/src/Money.Blazor.Host/Pages/OverviewIncome.razor
+++ b/src/Money.Blazor.Host/Pages/OverviewIncome.razor
@@ -10,50 +10,57 @@
 <IncomeCreate @ref="CreateModal" />
 
 <div class="container-narrow">
-    <Loading Context="@Loading" IsOverlay="true">
-        <ul class="nav nav-pills float-start">
-            <li>
-                <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
-            </li>
-            <li>
-                <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
-            </li>
-            @{
-                var checklistUrl = ChecklistUrl();
-            }
-            @if (checklistUrl != null)
-            {
-                <li>
-                    <a class="nav-link" href="@checklistUrl">Checklist</a>
-                </li>
-            }
-        </ul>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetPeriodsAsync" LinkFactory="UrlOverviewIncomes" />
+            <span class="ps-2">
+                <Loading Context="@Loading" IsOverlay="true" />
+            </span>
+        </div>
+    </div>
 
-        @if (Items?.Count > 0)
-        {
-            <SortButton TType="@IncomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
+    <ul class="nav nav-pills float-start">
+        <li>
+            <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
+        </li>
+        <li>
+            <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
+        </li>
+        @{
+            var checklistUrl = ChecklistUrl();
         }
-        <div class="clear"></div>
-
-        @if (Items != null)
+        @if (checklistUrl != null)
         {
-            if (Items.Count > 0)
-            {
-                <div class="cards">
-                    <IncomeCardContext>
-                        @foreach (var item in Items)
-                        {
-                            <IncomeCard Model="@item" />
-                        }
-                    </IncomeCardContext>
-                </div>
-
-                <Paging Context="@PagingContext" />
-            }
-            else
-            {
-                <Alert Title="No data." Message="Let's add some incomes." Mode="@AlertMode.Warning" CssClass="mt-3" />
-            }
+            <li>
+                <a class="nav-link" href="@checklistUrl">Checklist</a>
+            </li>
         }
-    </Loading>
+    </ul>
+
+    @if (Items?.Count > 0)
+    {
+        <SortButton TType="@IncomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
+    }
+    <div class="clear"></div>
+
+    @if (Items != null)
+    {
+        if (Items.Count > 0)
+        {
+            <div class="cards">
+                <IncomeCardContext>
+                    @foreach (var item in Items)
+                    {
+                        <IncomeCard Model="@item" />
+                    }
+                </IncomeCardContext>
+            </div>
+
+            <Paging Context="@PagingContext" />
+        }
+        else
+        {
+            <Alert Title="No data." Message="Let's add some incomes." Mode="@AlertMode.Warning" CssClass="mt-3" />
+        }
+    }
 </div>

--- a/src/Money.Blazor.Host/Pages/OverviewIncome.razor
+++ b/src/Money.Blazor.Host/Pages/OverviewIncome.razor
@@ -17,30 +17,32 @@
                 <Loading Context="@Loading" IsOverlay="true" />
             </span>
         </div>
-        <ul class="nav nav-pills">
-            <li>
-                <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
-            </li>
-            <li>
-                <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
-            </li>
-            @{
-                var checklistUrl = ChecklistUrl();
-            }
-            @if (checklistUrl != null)
-            {
+        <div class="d-flex align-items-center">
+            <ul class="nav nav-pills">
                 <li>
-                    <a class="nav-link" href="@checklistUrl">Checklist</a>
+                    <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
                 </li>
+                <li>
+                    <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
+                </li>
+                @{
+                    var checklistUrl = ChecklistUrl();
+                }
+                @if (checklistUrl != null)
+                {
+                    <li>
+                        <a class="nav-link" href="@checklistUrl">Checklist</a>
+                    </li>
+                }
+            </ul>
+            @if (Items?.Count > 0)
+            {
+                <span class="ps-2">
+                    <SortButton TType="@IncomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
+                </span>
             }
-        </ul>
+        </div>
     </div>
-
-    @if (Items?.Count > 0)
-    {
-        <SortButton TType="@IncomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
-    }
-    <div class="clear"></div>
 
     @if (Items != null)
     {

--- a/src/Money.Blazor.Host/Pages/OverviewIncome.razor
+++ b/src/Money.Blazor.Host/Pages/OverviewIncome.razor
@@ -17,25 +17,24 @@
                 <Loading Context="@Loading" IsOverlay="true" />
             </span>
         </div>
-    </div>
-
-    <ul class="nav nav-pills float-start">
-        <li>
-            <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
-        </li>
-        <li>
-            <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
-        </li>
-        @{
-            var checklistUrl = ChecklistUrl();
-        }
-        @if (checklistUrl != null)
-        {
+        <ul class="nav nav-pills">
             <li>
-                <a class="nav-link" href="@checklistUrl">Checklist</a>
+                <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
             </li>
-        }
-    </ul>
+            <li>
+                <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
+            </li>
+            @{
+                var checklistUrl = ChecklistUrl();
+            }
+            @if (checklistUrl != null)
+            {
+                <li>
+                    <a class="nav-link" href="@checklistUrl">Checklist</a>
+                </li>
+            }
+        </ul>
+    </div>
 
     @if (Items?.Count > 0)
     {

--- a/src/Money.Blazor.Host/Pages/OverviewIncome.razor.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewIncome.razor.cs
@@ -39,6 +39,7 @@ public partial class OverviewIncome<T>(
     protected string SubTitle { get; set; } = subTitle;
 
     protected T SelectedPeriod { get; set; }
+    protected IReadOnlyCollection<T> PeriodGuesses { get; set; }
     protected List<IncomeOverviewModel> Items { get; set; }
 
     protected IncomeCreate CreateModal { get; set; }
@@ -68,6 +69,7 @@ public partial class OverviewIncome<T>(
         base.OnParametersSet();
 
         SelectedPeriod = CreateSelectedItemFromParameters();
+        PeriodGuesses = CreatePeriodGuesses();
         Reload();
     }
 
@@ -79,6 +81,18 @@ public partial class OverviewIncome<T>(
 
     protected virtual IQuery<List<IncomeOverviewModel>> CreateItemsQuery(int pageIndex)
         => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(CreateItemsQuery)}'.");
+
+    protected virtual IReadOnlyCollection<T> CreatePeriodGuesses()
+        => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(CreatePeriodGuesses)}'.");
+
+    protected virtual IQuery<List<T>> CreatePeriodsQuery()
+        => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(CreatePeriodsQuery)}'.");
+
+    protected async Task<IReadOnlyCollection<T>> GetPeriodsAsync()
+        => await Queries.QueryAsync(CreatePeriodsQuery());
+
+    protected virtual string UrlOverviewIncomes(T period)
+        => throw Ensure.Exception.NotImplemented($"Missing override for method '{nameof(UrlOverviewIncomes)}'.");
 
     protected virtual string ListExpenseUrl()
         => null;

--- a/src/Money.Blazor.Host/Pages/OverviewMonth.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewMonth.cs
@@ -56,6 +56,15 @@ public partial class OverviewMonth(
     protected override MonthModel CreateSelectedItemFromParameters()
         => new MonthModel(Year.Value, Month.Value);
 
+    protected override IReadOnlyCollection<MonthModel> CreatePeriodGuesses()
+        => new MonthModel[] { SelectedPeriod - 1, SelectedPeriod - 2 };
+
+    protected override IQuery<List<MonthModel>> CreatePeriodsQuery()
+        => new ListMonthWithExpenseOrIncome();
+
+    protected override string UrlOverview(MonthModel period)
+        => CategoryKey.IsEmpty ? Navigator.UrlOverview(period) : Navigator.UrlOverview(period, CategoryKey);
+
     protected override IKey CreateSelectedCategoryFromParameters()
         => CategoryGuid != null ? GuidKey.Create(CategoryGuid.Value, KeyFactory.Empty(typeof(Category)).Type) : KeyFactory.Empty(typeof(Category));
 

--- a/src/Money.Blazor.Host/Pages/OverviewMonthIncome.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewMonthIncome.cs
@@ -40,6 +40,15 @@ public partial class OverviewMonthIncome(
     protected override MonthModel CreateSelectedItemFromParameters()
         => new MonthModel(Year.Value, Month.Value);
 
+    protected override IReadOnlyCollection<MonthModel> CreatePeriodGuesses()
+        => new MonthModel[] { SelectedPeriod - 1, SelectedPeriod - 2 };
+
+    protected override IQuery<List<MonthModel>> CreatePeriodsQuery()
+        => new ListMonthWithExpenseOrIncome();
+
+    protected override string UrlOverviewIncomes(MonthModel period)
+        => Navigator.UrlOverviewIncomes(period);
+
     protected override IQuery<List<IncomeOverviewModel>> CreateItemsQuery(int pageIndex)
         => new ListMonthIncome(SelectedPeriod, SortDescriptor, pageIndex);
 

--- a/src/Money.Blazor.Host/Pages/OverviewYear.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewYear.cs
@@ -49,6 +49,15 @@ public partial class OverviewYear(
     protected override YearModel CreateSelectedItemFromParameters()
         => new YearModel(Year.Value);
 
+    protected override IReadOnlyCollection<YearModel> CreatePeriodGuesses()
+        => new YearModel[] { SelectedPeriod - 1, SelectedPeriod - 2 };
+
+    protected override IQuery<List<YearModel>> CreatePeriodsQuery()
+        => new ListYearWithExpenseOrIncome();
+
+    protected override string UrlOverview(YearModel period)
+        => CategoryKey.IsEmpty ? Navigator.UrlOverview(period) : Navigator.UrlOverview(period, CategoryKey);
+
     protected override IKey CreateSelectedCategoryFromParameters()
         => CategoryGuid != null ? GuidKey.Create(CategoryGuid.Value, KeyFactory.Empty(typeof(Category)).Type) : KeyFactory.Empty(typeof(Category));
 

--- a/src/Money.Blazor.Host/Pages/OverviewYearIncome.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewYearIncome.cs
@@ -36,6 +36,15 @@ public partial class OverviewYearIncome(
     protected override YearModel CreateSelectedItemFromParameters()
         => new YearModel(Year.Value);
 
+    protected override IReadOnlyCollection<YearModel> CreatePeriodGuesses()
+        => new YearModel[] { SelectedPeriod - 1, SelectedPeriod - 2 };
+
+    protected override IQuery<List<YearModel>> CreatePeriodsQuery()
+        => new ListYearWithExpenseOrIncome();
+
+    protected override string UrlOverviewIncomes(YearModel period)
+        => Navigator.UrlOverviewIncomes(period);
+
     protected override IQuery<List<IncomeOverviewModel>> CreateItemsQuery(int pageIndex)
         => new ListYearIncome(SelectedPeriod, SortDescriptor, pageIndex);
 

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -1,16 +1,7 @@
 ﻿@attribute [Authorize]
 @page "/{Year:int}/trends/{CategoryGuid:guid}"
 
-<Title Icon="chart-line" Main="@($"{CategoryName} trends in {Year}")" Sub="See how the category expenses change in time">
-    <ButtonContent>
-        <button class="btn btn-secondary" @onclick="(() => Navigator.OpenOverview(SelectedPeriod, CategoryKey))">
-            <Icon Prefix="fas" Identifier="list-ul" />
-            <span class="d-none d-lg-inline">
-                Year overview
-            </span>
-        </button>
-    </ButtonContent>
-</Title>
+<Title Icon="chart-line" Main="@($"{CategoryName} trends in {Year}")" Sub="See how the category expenses change in time" />
 
 @if (Models == null)
 {
@@ -22,6 +13,14 @@ else
         <div>
             <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetYearsAsync" LinkFactory="@(year => Navigator.UrlTrends(year, CategoryKey))" />
         </div>
+        <ul class="nav nav-pills">
+            <li>
+                <a class="nav-link" href="@Navigator.UrlOverview(SelectedPeriod, CategoryKey)">Overview</a>
+            </li>
+            <li>
+                <a class="nav-link active" href="@Navigator.UrlTrends(SelectedPeriod, CategoryKey)">Trends</a>
+            </li>
+        </ul>
     </div>
 
     <div class="row no-gutters" style="min-height: calc(100vh - 312px)">

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -9,11 +9,11 @@
 }
 else
 {
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex align-items-center mb-3">
         <div>
             <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetYearsAsync" LinkFactory="@(year => Navigator.UrlTrends(year, CategoryKey))" />
         </div>
-        <ul class="nav nav-pills">
+        <ul class="nav nav-pills ps-3">
             <li>
                 <a class="nav-link" href="@Navigator.UrlOverview(SelectedPeriod, CategoryKey)">Overview</a>
             </li>

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -18,6 +18,12 @@
 }
 else
 {
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetYearsAsync" LinkFactory="@(year => Navigator.UrlTrends(year, CategoryKey))" />
+        </div>
+    </div>
+
     <div class="row no-gutters" style="min-height: calc(100vh - 312px)">
         @foreach (var model in Models)
         {

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -21,7 +21,7 @@ else
     <div class="row no-gutters" style="min-height: calc(100vh - 312px)">
         @foreach (var model in Models)
         {
-            var size = model.TotalAmount.Value / MaxAmount * 100;
+            var size = MaxAmount > 0 ? model.TotalAmount.Value / MaxAmount * 100 : 0;
 
             <div class="col-12 col-lg-1 @(model > AppDateTime.Today ? "text-muted" : String.Empty)">
                 <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor.cs
@@ -21,6 +21,7 @@ public partial class TrendsMonth(IQueryDispatcher Queries, Navigator Navigator)
     public Guid CategoryGuid { get; set; }
 
     protected YearModel SelectedPeriod { get; set; }
+    protected IReadOnlyCollection<YearModel> PeriodGuesses { get; set; }
     protected IKey CategoryKey { get; set; }
     protected string CategoryName { get; set; }
     protected Color CategoryColor { get; set; }
@@ -32,12 +33,16 @@ public partial class TrendsMonth(IQueryDispatcher Queries, Navigator Navigator)
         await base.OnInitializedAsync();
 
         SelectedPeriod = new YearModel(Year);
+        PeriodGuesses = new YearModel[] { SelectedPeriod - 1, SelectedPeriod - 2 };
         CategoryKey = GuidKey.Create(CategoryGuid, KeyFactory.Empty(typeof(Category)).Type);
         CategoryName = await Queries.QueryAsync(new GetCategoryName(CategoryKey));
         CategoryColor = await Queries.QueryAsync(new GetCategoryColor(CategoryKey));
 
         await LoadAsync();
     }
+
+    protected async Task<IReadOnlyCollection<YearModel>> GetYearsAsync()
+        => await Queries.QueryAsync(new ListYearWithExpenseOrIncome());
 
     private async Task LoadAsync()
     {


### PR DESCRIPTION
Several pages have period parameters (month/year routing) but lacked the `PeriodSelector` UI that Summary and Balances already use. This makes it harder for users to jump to a specific period without manually editing the URL or relying solely on swipe gestures.

## Approach

Added `PeriodSelector` to the following page families by extending their base classes with the required properties and abstract methods:

- **Overview\<T\>** (expenses list) -- adds `PeriodGuesses`, `CreatePeriodGuesses()`, `CreatePeriodsQuery()`, `GetPeriodsAsync()`, and `UrlOverview()` to the base; implemented in `OverviewMonth` (uses `ListMonthWithExpenseOrIncome`) and `OverviewYear` (uses `ListYearWithExpenseOrIncome`)
- **OverviewIncome\<T\>** (incomes list) -- same pattern; implemented in `OverviewMonthIncome` and `OverviewYearIncome`
- **ExpenseChecklistMonth** -- standalone page, adds `PeriodGuesses` and `GetMonthsAsync()` directly

The selector is placed in a `d-flex justify-content-between` container above the nav tabs, matching the visual pattern used in Summary and Balances. Existing swipe navigation is preserved as-is -- the PeriodSelector is purely additive.

## Notes

- The `LinkFactory` for Overview pages accounts for the optional category filter (passes `CategoryKey` when non-empty).
- Period guesses follow the same convention as SummaryMonth: show the two preceding periods as quick-access links.