### PR TITLE
Add px-0 to buttons in bottom menu offcanvas

### DIFF
--- a/src/Money.Blazor.Host/Layouts/BottomMenu.razor
+++ b/src/Money.Blazor.Host/Layouts/BottomMenu.razor
@@ -84,7 +84,7 @@
                 @if (item.Url != null)
                 {
                     <Match Url="@item.Url" PageType="@item.PageType" Mode="@item.UrlMatch" Context="IsActive">
-                        <a href="@item.Url" class="btn border-0 @(IsActive ? "text-primary" : "") py-3 w-100" @onclick="(() => OnLinkClick(item.IsBlurMenuAfterClick))">
+                        <a href="@item.Url" class="btn border-0 @(IsActive ? "text-primary" : "") px-0 py-3 w-100" @onclick="(() => OnLinkClick(item.IsBlurMenuAfterClick))">
                             <Icon Identifier="@item.Icon" />
                             <span class="small text d-block text-truncate">
                                 @item.Text
@@ -94,7 +94,7 @@
                 }
                 else
                 {
-                    <button @onclick="@item.OnClick" class="btn border-0 @(isLogout ? "text-danger" : string.Empty) py-3 w-100">
+                    <button @onclick="@item.OnClick" class="btn border-0 @(isLogout ? "text-danger" : string.Empty) px-0 py-3 w-100">
                         <Icon Identifier="@item.Icon" />
                         <span class="small text d-block">
                             @item.Text


### PR DESCRIPTION
Removes horizontal padding from the buttons and links inside the bottom menu offcanvas grid, preventing text truncation on narrow columns.

Adds `px-0` to both the `<a>` and `<button>` elements in the `MainMenuItem` render fragment.