### PR TITLE
Make IncludeExpectedExpenses opt-in on balances page

### DIFF
--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
@@ -32,7 +32,7 @@ public partial class BalancesMonth(
     protected LoadingContext Loading { get; set; } = new();
     protected YearModel SelectedPeriod { get; set; }
     protected BalanceDisplayType SelectedDisplayType { get; set; }
-    protected bool IncludeExpectedExpenses { get; set; } = true;
+    protected bool IncludeExpectedExpenses { get; set; }
     protected List<YearModel> PeriodGuesses { get; set; }
     protected List<MonthBalanceModel> Models { get; set; }
     protected decimal MaxAmount { get; set; }


### PR DESCRIPTION
The expected expenses query on the monthly balances page is currently quite slow, degrading the page load experience.

This flips `IncludeExpectedExpenses` from opt-out (default true) to opt-in (default false) so the page loads quickly by default. Users who want to see expected expenses can still toggle the checkbox.