### PR TITLE
Update release notes for blazor-v1.21.0

### DIFF
--- a/src/Money.Blazor.Host/wwwroot/release-notes.html
+++ b/src/Money.Blazor.Host/wwwroot/release-notes.html
@@ -5,11 +5,11 @@
     <li>Calendar picker replaces the date box when selecting an expense date.</li>
     <li>Submitting a zero amount expense skips a scheduled expense for the period.</li>
     <li>Context menu to change an expense on the Monthly checklist.</li>
-    <li>Pass 'Expected when' when creating an expense from the checklist.</li>
+    <li>Pass the 'Expected when' value when creating an expense from the checklist.</li>
     <li>Use keyboard arrows to navigate in the category picker.</li>
     <li>Templates search filter is preserved in browser history.</li>
     <li>Reduced placeholders on Overview for periods in the future.</li>
-    <li>Form is disabled while submitting to prevent double submit.</li>
+    <li>Form is disabled while submitting to prevent double submission.</li>
 </ul>
 
 <h3>Fixed bugs</h3>

--- a/src/Money.Blazor.Host/wwwroot/release-notes.html
+++ b/src/Money.Blazor.Host/wwwroot/release-notes.html
@@ -1,20 +1,29 @@
 ﻿<h3>New features</h3>
 <ul>
-    <li>Calendar view for expenses created from expense template.</li>
-    <li>New every X months recurring period for expense templates.</li>
-    <li>New once a year recurring period for expense templates.</li>
-    <li>If expense happen at different date then it was expected, it can be adjusted with 'Expected when' field.</li>
+    <li>Yearly income overview page.</li>
+    <li>Income search page.</li>
+    <li>Calendar picker replaces the date box when selecting an expense date.</li>
+    <li>Submitting a zero amount expense skips a scheduled expense for the period.</li>
+    <li>Context menu to change an expense on the Monthly checklist.</li>
+    <li>Pass 'Expected when' when creating an expense from the checklist.</li>
+    <li>Use keyboard arrows to navigate in the category picker.</li>
+    <li>Templates search filter is preserved in browser history.</li>
+    <li>Reduced placeholders on Overview for periods in the future.</li>
+    <li>Form is disabled while submitting to prevent double submit.</li>
 </ul>
 
 <h3>Fixed bugs</h3>
 <ul>
-    <li>Balances overlapping footer.</li>
-    <li>Expense template create dialog fails when user don't have any category or currency.</li>
+    <li>Multiple menu items highlighted for settings and password.</li>
+    <li>Overview applied an expense that didn't fit the current category.</li>
+    <li>Currency was reset to default when changing the amount.</li>
+    <li>Couldn't enter an expense with decimals when display was set to hide decimals.</li>
+    <li>Couldn't reset the amount on an existing expense template.</li>
 </ul>
 
 <div class="row">
     <div class="col-12 col-md-auto">
-        <a target="_blank" href="https://github.com/maraf/Money/releases/blazor-v1.20.0" class="btn bg-light-subtle w-100">
+        <a target="_blank" href="https://github.com/maraf/Money/releases/blazor-v1.21.0" class="btn bg-light-subtle w-100">
             <span class="fab fa-github"></span>
             See details on GitHub
         </a>


### PR DESCRIPTION
Refreshes the in-app release notes shown to users when an update is available, ahead of tagging `blazor-v1.21.0`.

Compiled from the 18 closed issues in the `blazor-v1.21.0` milestone and grouped to match the established style:

**New features**
- Yearly income overview page (#657)
- Income search page (#644)
- Calendar picker replaces the date box for expense dates (#646, #613)
- Submitting a zero-amount expense skips a scheduled expense (#641)
- Context menu to change an expense on the Monthly checklist (#604)
- Pass `Expected when` when creating an expense from the checklist (#648)
- Keyboard arrow navigation in the category picker (#542)
- Templates search filter preserved in browser history (#608)
- Reduced placeholders in Overview for future periods (#597)
- Form disabled while submitting to prevent double submit (#562)

**Fixed bugs**
- Multiple menu items highlighted for settings and password (#616)
- Overview applied an expense that didn't fit the current category (#605)
- Currency reset to default when changing the amount (#603)
- Couldn't enter an expense with decimals when display was set to hide decimals (#602)
- Couldn't reset the amount on an existing expense template (#600)

The "See details on GitHub" link is bumped to `blazor-v1.21.0`. Internal-only items (#624 .NET 10 migration, #601 cryptic JS error) are intentionally omitted from user-facing notes.
