### PR TITLE
Update release notes and bump version to 1.21.1

### DIFF
--- a/src/Money.Blazor.Host/Money.Blazor.Host.csproj
+++ b/src/Money.Blazor.Host/Money.Blazor.Host.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Money</RootNamespace>
     <PublishDomain>app.money.neptuo.com</PublishDomain>
-    <VersionPrefix>1.20.0.0</VersionPrefix>
+    <VersionPrefix>1.21.1.0</VersionPrefix>
     <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
 	  <WasmFingerprintAssets Condition="'$(Configuration)' == 'Debug'">false</WasmFingerprintAssets>

--- a/src/Money.Blazor.Host/wwwroot/release-notes.html
+++ b/src/Money.Blazor.Host/wwwroot/release-notes.html
@@ -1,29 +1,11 @@
-﻿<h3>New features</h3>
+﻿<h3>Fixed bugs</h3>
 <ul>
-    <li>Yearly income overview page.</li>
-    <li>Income search page.</li>
-    <li>Calendar picker replaces the date box when selecting an expense date.</li>
-    <li>Submitting a zero amount expense skips a scheduled expense for the period.</li>
-    <li>Context menu to change an expense on the Monthly checklist.</li>
-    <li>Pass the 'Expected when' value when creating an expense from the checklist.</li>
-    <li>Use keyboard arrows to navigate in the category picker.</li>
-    <li>Templates search filter is preserved in browser history.</li>
-    <li>Reduced placeholders on Overview for periods in the future.</li>
-    <li>Form is disabled while submitting to prevent double submission.</li>
-</ul>
-
-<h3>Fixed bugs</h3>
-<ul>
-    <li>Multiple menu items highlighted for settings and password.</li>
-    <li>Overview applied an expense that didn't fit the current category.</li>
-    <li>Currency was reset to default when changing the amount.</li>
-    <li>Couldn't enter an expense with decimals when display was set to hide decimals.</li>
-    <li>Couldn't reset the amount on an existing expense template.</li>
+    <li>Mobile bottom menu has 1px gap between bottom bar.</li>
 </ul>
 
 <div class="row">
     <div class="col-12 col-md-auto">
-        <a target="_blank" href="https://github.com/maraf/Money/releases/blazor-v1.21.0" class="btn bg-light-subtle w-100">
+        <a target="_blank" href="https://github.com/maraf/Money/releases/blazor-v1.21.1" class="btn bg-light-subtle w-100">
             <span class="fab fa-github"></span>
             See details on GitHub
         </a>


### PR DESCRIPTION
Prepares the blazor-v1.21.1 release by updating the in-app release notes and bumping the version number.

**Changes:**
- Replace release-notes.html content with the single bug fix from the blazor-v1.21.1 milestone: "Mobile bottom menu has 1px gap between bottom bar" (#666)
- Bump `VersionPrefix` in `Money.Blazor.Host.csproj` from `1.20.0.0` to `1.21.1.0`