### PR TITLE
Add placeholder skeletons for data loading in IncomeOverview

### DIFF
--- a/src/Money.Blazor.Host/Pages/OverviewIncome.razor
+++ b/src/Money.Blazor.Host/Pages/OverviewIncome.razor
@@ -38,6 +38,7 @@
         <IncomeCardContext>
             <AutoLoadListView
                 Items="@Items"
+                PlaceholderCount="2"
                 LoadingContext="@Loading"
                 PagingContext="@PagingContext"
                 NoDataTitle="No data."

--- a/src/Money.Blazor.Host/Pages/OverviewIncome.razor
+++ b/src/Money.Blazor.Host/Pages/OverviewIncome.razor
@@ -10,50 +10,42 @@
 <IncomeCreate @ref="CreateModal" />
 
 <div class="container-narrow">
-    <Loading Context="@Loading" IsOverlay="true">
-        <ul class="nav nav-pills float-start">
-            <li>
-                <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
-            </li>
-            <li>
-                <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
-            </li>
-            @{
-                var checklistUrl = ChecklistUrl();
-            }
-            @if (checklistUrl != null)
-            {
-                <li>
-                    <a class="nav-link" href="@checklistUrl">Checklist</a>
-                </li>
-            }
-        </ul>
-
-        @if (Items?.Count > 0)
-        {
-            <SortButton TType="@IncomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
+    <ul class="nav nav-pills float-start">
+        <li>
+            <a class="nav-link active" href="@Navigator.UrlCurrent()">Incomes</a>
+        </li>
+        <li>
+            <a class="nav-link" href="@ListExpenseUrl()">Expenses</a>
+        </li>
+        @{
+            var checklistUrl = ChecklistUrl();
         }
-        <div class="clear"></div>
-
-        @if (Items != null)
+        @if (checklistUrl != null)
         {
-            if (Items.Count > 0)
-            {
-                <div class="cards">
-                    <IncomeCardContext>
-                        @foreach (var item in Items)
-                        {
-                            <IncomeCard Model="@item" />
-                        }
-                    </IncomeCardContext>
-                </div>
-
-                <Paging Context="@PagingContext" />
-            }
-            else
-            {
-                <Alert Title="No data." Message="Let's add some incomes." Mode="@AlertMode.Warning" CssClass="mt-3" />
-            }
+            <li>
+                <a class="nav-link" href="@checklistUrl">Checklist</a>
+            </li>
         }
-    </Loading>
+    </ul>
+
+    @if (Items?.Count > 0)
+    {
+        <SortButton TType="@IncomeOverviewSortType" @bind-Current="@SortDescriptor" Changed="@OnSortChanged" />
+    }
+    <div class="clear"></div>
+
+    <div class="cards">
+        <IncomeCardContext>
+            <AutoLoadListView
+                Items="@Items"
+                LoadingContext="@Loading"
+                PagingContext="@PagingContext"
+                NoDataTitle="No data."
+                NoDataMessage="Let's add some incomes."
+                Context="item"
+            >
+                <IncomeCard Model="@item.Model" CssClass="@item.Placeholder?.CssClass" />
+            </AutoLoadListView>
+        </IncomeCardContext>
+    </div>
 </div>

--- a/src/Money.Blazor.Host/Pages/OverviewIncome.razor.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewIncome.razor.cs
@@ -116,7 +116,11 @@ public partial class OverviewIncome<T>(
             return PagingLoadStatus.EmptyPage;
         }
 
-        Items = models;
+        if (Items == null || PagingContext.CurrentPageIndex == 0)
+            Items = models;
+        else
+            Items.AddRange(models);
+
         return Items.Count == 10 ? PagingLoadStatus.HasNextPage : PagingLoadStatus.LastPage;
     }
 
@@ -164,6 +168,9 @@ public partial class OverviewIncome<T>(
 
     protected Task OnEventAsync(IKey aggregateKey, Action<IncomeOverviewModel> handler)
     {
+        if (Items == null)
+            return Task.CompletedTask;
+
         var item = Items.FirstOrDefault(i => i.Key.Equals(aggregateKey));
         if (item != null)
             handler(item);

--- a/src/Money.Blazor.Host/Pages/OverviewIncome.razor.cs
+++ b/src/Money.Blazor.Host/Pages/OverviewIncome.razor.cs
@@ -97,6 +97,8 @@ public partial class OverviewIncome<T>(
 
     protected async void Reload()
     {
+        Items = null;
+        StateHasChanged();
         await PagingContext.LoadAsync(0);
         StateHasChanged();
     }
@@ -120,6 +122,8 @@ public partial class OverviewIncome<T>(
 
     protected async void OnSortChanged()
     {
+        Items = null;
+        StateHasChanged();
         await PagingContext.LoadAsync(0);
         StateHasChanged();
     }


### PR DESCRIPTION
The IncomeOverview page used a translucent loading overlay which left the UI feeling unresponsive during data fetches. Other list pages (expenses Overview, SearchIncomes) already use the `AutoLoadListView` component that renders animated placeholder skeletons -- a much better loading UX.

This PR replaces the `<Loading IsOverlay="true">` wrapper with `AutoLoadListView` in `OverviewIncome.razor`, and clears `Items` before reload so placeholders appear immediately when switching periods or changing sort order.

- Replaced manual item loop + Loading overlay with `AutoLoadListView` component
- Added `PlaceholderCount="2"` to show 2 skeleton cards during loading
- Clear `Items = null` in `Reload()` and `OnSortChanged()` so stale data is not shown above placeholders

Fixes: #582