### PR TITLE
Add push notifications for scheduled expenses

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageVersion Include="WebPush" Version="1.0.13" />
   </ItemGroup>
 
 </Project>

--- a/src/Money.Accounts.EntityFrameworkCore/AccountContext.cs
+++ b/src/Money.Accounts.EntityFrameworkCore/AccountContext.cs
@@ -14,6 +14,10 @@ namespace Money
         private readonly SchemaOptions schema;
 
         public DbSet<UserPropertyValue> UserProperties { get; set; }
+        public DbSet<PushSubscription> PushSubscriptions { get; set; }
+        public DbSet<UserNotificationSettings> UserNotificationSettings { get; set; }
+        public DbSet<UserNotificationExpenseTemplateSettings> UserNotificationExpenseTemplateSettings { get; set; }
+        public DbSet<ExpenseTemplateNotificationDispatch> ExpenseTemplateNotificationDispatches { get; set; }
 
         public AccountContext(DbContextOptions<AccountContext> options, SchemaOptions<AccountContext> schema)
             : base(options)
@@ -41,6 +45,44 @@ namespace Money
             modelBuilder.Entity<UserPropertyValue>()
                 .Property(p => p.Value)
                 .HasMaxLength(1024);
+
+            modelBuilder.Entity<PushSubscription>()
+                .HasIndex(p => p.Endpoint)
+                .IsUnique();
+
+            modelBuilder.Entity<PushSubscription>()
+                .HasOne(p => p.User)
+                .WithMany()
+                .HasForeignKey(p => p.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<UserNotificationSettings>()
+                .HasKey(s => s.UserId);
+
+            modelBuilder.Entity<UserNotificationSettings>()
+                .HasOne(s => s.User)
+                .WithMany()
+                .HasForeignKey(s => s.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<UserNotificationExpenseTemplateSettings>()
+                .HasKey(s => s.UserId);
+
+            modelBuilder.Entity<UserNotificationExpenseTemplateSettings>()
+                .HasOne(s => s.User)
+                .WithMany()
+                .HasForeignKey(s => s.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<ExpenseTemplateNotificationDispatch>()
+                .HasIndex(d => new { d.UserId, d.ExpenseTemplateId, d.Date })
+                .IsUnique();
+
+            modelBuilder.Entity<ExpenseTemplateNotificationDispatch>()
+                .HasOne(d => d.User)
+                .WithMany()
+                .HasForeignKey(d => d.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
 
             if (!String.IsNullOrEmpty(schema.Name))
             {

--- a/src/Money.Accounts.EntityFrameworkCore/ExpenseTemplateNotificationDispatch.cs
+++ b/src/Money.Accounts.EntityFrameworkCore/ExpenseTemplateNotificationDispatch.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Money;
+
+public class ExpenseTemplateNotificationDispatch
+{
+    public int Id { get; set; }
+    public string UserId { get; set; }
+    public Guid ExpenseTemplateId { get; set; }
+    public DateTime Date { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? SentAt { get; set; }
+
+    public User User { get; set; }
+}

--- a/src/Money.Accounts.EntityFrameworkCore/PushSubscription.cs
+++ b/src/Money.Accounts.EntityFrameworkCore/PushSubscription.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Money;
+
+public class PushSubscription
+{
+    public int Id { get; set; }
+    public string UserId { get; set; }
+    public string Endpoint { get; set; }
+    public string P256dh { get; set; }
+    public string Auth { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? RevokedAt { get; set; }
+
+    public User User { get; set; }
+}

--- a/src/Money.Accounts.EntityFrameworkCore/UserNotificationExpenseTemplateSettings.cs
+++ b/src/Money.Accounts.EntityFrameworkCore/UserNotificationExpenseTemplateSettings.cs
@@ -1,0 +1,11 @@
+namespace Money;
+
+public class UserNotificationExpenseTemplateSettings
+{
+    public string UserId { get; set; }
+    public bool IsEnabled { get; set; }
+    public int PreferredHour { get; set; }
+    public string TimeZone { get; set; }
+
+    public User User { get; set; }
+}

--- a/src/Money.Accounts.EntityFrameworkCore/UserNotificationSettings.cs
+++ b/src/Money.Accounts.EntityFrameworkCore/UserNotificationSettings.cs
@@ -1,0 +1,9 @@
+namespace Money;
+
+public class UserNotificationSettings
+{
+    public string UserId { get; set; }
+    public bool IsEnabled { get; set; }
+
+    public User User { get; set; }
+}

--- a/src/Money.Api.Shared/Accounts/Models/ExpenseTemplateNotificationSettingsModel.cs
+++ b/src/Money.Api.Shared/Accounts/Models/ExpenseTemplateNotificationSettingsModel.cs
@@ -1,0 +1,8 @@
+namespace Money.Accounts.Models;
+
+public class ExpenseTemplateNotificationSettingsModel
+{
+    public bool IsEnabled { get; set; }
+    public int PreferredHour { get; set; }
+    public string TimeZone { get; set; }
+}

--- a/src/Money.Api.Shared/Accounts/Models/ExpenseTemplateNotificationSettingsRequest.cs
+++ b/src/Money.Api.Shared/Accounts/Models/ExpenseTemplateNotificationSettingsRequest.cs
@@ -1,0 +1,8 @@
+namespace Money.Accounts.Models;
+
+public class ExpenseTemplateNotificationSettingsRequest
+{
+    public bool IsEnabled { get; set; }
+    public int PreferredHour { get; set; }
+    public string TimeZone { get; set; }
+}

--- a/src/Money.Api.Shared/Accounts/Models/NotificationSettingsModel.cs
+++ b/src/Money.Api.Shared/Accounts/Models/NotificationSettingsModel.cs
@@ -1,0 +1,9 @@
+namespace Money.Accounts.Models;
+
+public class NotificationSettingsModel
+{
+    public bool IsEnabled { get; set; }
+    public bool HasSubscription { get; set; }
+    public string PushPublicKey { get; set; }
+    public ExpenseTemplateNotificationSettingsModel ExpenseTemplates { get; set; }
+}

--- a/src/Money.Api.Shared/Accounts/Models/NotificationSettingsRequest.cs
+++ b/src/Money.Api.Shared/Accounts/Models/NotificationSettingsRequest.cs
@@ -1,0 +1,6 @@
+namespace Money.Accounts.Models;
+
+public class NotificationSettingsRequest
+{
+    public bool IsEnabled { get; set; }
+}

--- a/src/Money.Api.Shared/Accounts/Models/PushSubscriptionEndpointRequest.cs
+++ b/src/Money.Api.Shared/Accounts/Models/PushSubscriptionEndpointRequest.cs
@@ -1,0 +1,6 @@
+namespace Money.Accounts.Models;
+
+public class PushSubscriptionEndpointRequest
+{
+    public string Endpoint { get; set; }
+}

--- a/src/Money.Api.Shared/Accounts/Models/PushSubscriptionModel.cs
+++ b/src/Money.Api.Shared/Accounts/Models/PushSubscriptionModel.cs
@@ -1,0 +1,8 @@
+namespace Money.Accounts.Models;
+
+public class PushSubscriptionModel
+{
+    public string Endpoint { get; set; }
+    public string P256dh { get; set; }
+    public string Auth { get; set; }
+}

--- a/src/Money.Api/Accounts/Controllers/NotificationsController.cs
+++ b/src/Money.Api/Accounts/Controllers/NotificationsController.cs
@@ -1,0 +1,147 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Money.Accounts.Models;
+using Money.Services;
+using Neptuo;
+using Neptuo.Activators;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Money.Accounts.Controllers;
+
+[Authorize]
+[Route("api/notifications")]
+[ApiController]
+public class NotificationsController : ControllerBase
+{
+    private readonly IFactory<AccountContext> dbFactory;
+    private readonly PushNotificationSender pushSender;
+    private readonly Json json;
+
+    public NotificationsController(IFactory<AccountContext> dbFactory, PushNotificationSender pushSender, Json json)
+    {
+        Ensure.NotNull(dbFactory, "dbFactory");
+        Ensure.NotNull(pushSender, "pushSender");
+        Ensure.NotNull(json, "json");
+        this.dbFactory = dbFactory;
+        this.pushSender = pushSender;
+        this.json = json;
+    }
+
+    private string GetUserId() => User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+    [HttpGet]
+    public async Task<IActionResult> GetSettings()
+    {
+        string userId = GetUserId();
+        using var db = dbFactory.Create();
+
+        var settings = await db.UserNotificationSettings.FindAsync(userId);
+        var expenseSettings = await db.UserNotificationExpenseTemplateSettings.FindAsync(userId);
+        var hasSubscription = await db.PushSubscriptions.AnyAsync(s => s.UserId == userId && s.RevokedAt == null);
+
+        var model = new NotificationSettingsModel
+        {
+            IsEnabled = settings?.IsEnabled ?? false,
+            HasSubscription = hasSubscription,
+            PushPublicKey = pushSender.PublicKey,
+            ExpenseTemplates = new ExpenseTemplateNotificationSettingsModel
+            {
+                IsEnabled = expenseSettings?.IsEnabled ?? false,
+                PreferredHour = expenseSettings?.PreferredHour ?? 8,
+                TimeZone = expenseSettings?.TimeZone ?? "UTC"
+            }
+        };
+
+        return Content(json.Serialize(model), "text/json");
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> PutSettings([FromBody] NotificationSettingsRequest request)
+    {
+        string userId = GetUserId();
+        using var db = dbFactory.Create();
+
+        var settings = await db.UserNotificationSettings.FindAsync(userId);
+        if (settings == null)
+        {
+            settings = new UserNotificationSettings { UserId = userId };
+            db.UserNotificationSettings.Add(settings);
+        }
+
+        settings.IsEnabled = request.IsEnabled;
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpPut("expense-templates")]
+    public async Task<IActionResult> PutExpenseTemplateSettings([FromBody] ExpenseTemplateNotificationSettingsRequest request)
+    {
+        string userId = GetUserId();
+        using var db = dbFactory.Create();
+
+        var expenseSettings = await db.UserNotificationExpenseTemplateSettings.FindAsync(userId);
+        if (expenseSettings == null)
+        {
+            expenseSettings = new UserNotificationExpenseTemplateSettings { UserId = userId };
+            db.UserNotificationExpenseTemplateSettings.Add(expenseSettings);
+        }
+
+        expenseSettings.IsEnabled = request.IsEnabled;
+        expenseSettings.PreferredHour = request.PreferredHour;
+        expenseSettings.TimeZone = request.TimeZone;
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpPost("subscriptions")]
+    public async Task<IActionResult> Subscribe([FromBody] PushSubscriptionModel model)
+    {
+        string userId = GetUserId();
+        using var db = dbFactory.Create();
+
+        var existing = await db.PushSubscriptions.FirstOrDefaultAsync(s => s.Endpoint == model.Endpoint);
+        if (existing != null)
+        {
+            existing.P256dh = model.P256dh;
+            existing.Auth = model.Auth;
+            existing.UserId = userId;
+            existing.RevokedAt = null;
+        }
+        else
+        {
+            db.PushSubscriptions.Add(new PushSubscription
+            {
+                UserId = userId,
+                Endpoint = model.Endpoint,
+                P256dh = model.P256dh,
+                Auth = model.Auth,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpDelete("subscriptions")]
+    public async Task<IActionResult> Unsubscribe([FromBody] PushSubscriptionEndpointRequest request)
+    {
+        string userId = GetUserId();
+        using var db = dbFactory.Create();
+
+        var subscription = await db.PushSubscriptions
+            .FirstOrDefaultAsync(s => s.UserId == userId && s.Endpoint == request.Endpoint);
+
+        if (subscription != null)
+        {
+            subscription.RevokedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+        }
+
+        return Ok();
+    }
+}

--- a/src/Money.Api/Accounts/ExpenseTemplateNotificationBackgroundService.cs
+++ b/src/Money.Api/Accounts/ExpenseTemplateNotificationBackgroundService.cs
@@ -1,0 +1,183 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Money.Accounts.Models;
+using Money.Models;
+using Neptuo.Activators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Money.Accounts;
+
+public class ExpenseTemplateNotificationBackgroundService : BackgroundService
+{
+    private readonly IServiceScopeFactory scopeFactory;
+    private readonly IOptions<NotificationOptions> options;
+    private readonly TimeProvider timeProvider;
+    private readonly ILogger<ExpenseTemplateNotificationBackgroundService> logger;
+
+    public ExpenseTemplateNotificationBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IOptions<NotificationOptions> options,
+        TimeProvider timeProvider,
+        ILogger<ExpenseTemplateNotificationBackgroundService> logger)
+    {
+        this.scopeFactory = scopeFactory;
+        this.options = options;
+        this.timeProvider = timeProvider;
+        this.logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await NotifyDueTemplatesAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error processing expense template notifications.");
+            }
+
+            await Task.Delay(options.Value.ExpenseTemplates.TickInterval, stoppingToken);
+        }
+    }
+
+    private async Task NotifyDueTemplatesAsync(CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var accountDbFactory = scope.ServiceProvider.GetRequiredService<IFactory<AccountContext>>();
+        var readModelDbFactory = scope.ServiceProvider.GetRequiredService<IFactory<ReadModelContext>>();
+        var pushSender = scope.ServiceProvider.GetRequiredService<PushNotificationSender>();
+
+        if (!pushSender.IsConfigured)
+            return;
+
+        using var accountDb = accountDbFactory.Create();
+
+        var candidates = await accountDb.UserNotificationExpenseTemplateSettings
+            .Where(s => s.IsEnabled)
+            .ToListAsync(ct);
+
+        if (candidates.Count == 0)
+            return;
+
+        foreach (var candidate in candidates)
+        {
+            try
+            {
+                TimeZoneInfo tz;
+                try
+                {
+                    tz = TimeZoneInfo.FindSystemTimeZoneById(candidate.TimeZone);
+                }
+                catch (TimeZoneNotFoundException)
+                {
+                    logger.LogWarning("Unknown timezone {TimeZone} for user {UserId}, skipping.", candidate.TimeZone, candidate.UserId);
+                    continue;
+                }
+
+                var utcNow = timeProvider.GetUtcNow();
+                var userLocalTime = TimeZoneInfo.ConvertTimeFromUtc(utcNow.UtcDateTime, tz);
+                if (userLocalTime.Hour != candidate.PreferredHour)
+                    continue;
+
+                var globalSettings = await accountDb.UserNotificationSettings.FindAsync(new object[] { candidate.UserId }, ct);
+                if (globalSettings == null || !globalSettings.IsEnabled)
+                    continue;
+
+                var today = DateOnly.FromDateTime(userLocalTime);
+                await SendNotificationsForUserAsync(candidate.UserId, today, accountDb, readModelDbFactory, pushSender, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error processing notifications for user {UserId}.", candidate.UserId);
+            }
+        }
+    }
+
+    private async Task SendNotificationsForUserAsync(
+        string userId,
+        DateOnly today,
+        AccountContext accountDb,
+        IFactory<ReadModelContext> readModelDbFactory,
+        PushNotificationSender pushSender,
+        CancellationToken ct)
+    {
+        using var readModelDb = readModelDbFactory.Create();
+
+        var templates = await readModelDb.ExpenseTemplates
+            .Where(t => t.UserId == userId && !t.IsDeleted && t.Period != null)
+            .ToListAsync(ct);
+
+        var dueTemplates = templates.Where(t => IsDueToday(t, today)).ToList();
+        if (dueTemplates.Count == 0)
+            return;
+
+        var alreadySent = await accountDb.ExpenseTemplateNotificationDispatches
+            .Where(d => d.UserId == userId && d.Date == today.ToDateTime(TimeOnly.MinValue))
+            .Select(d => d.ExpenseTemplateId)
+            .ToListAsync(ct);
+
+        var toNotify = dueTemplates.Where(t => !alreadySent.Contains(t.Id)).ToList();
+        if (toNotify.Count == 0)
+            return;
+
+        var title = toNotify.Count == 1
+            ? "Scheduled expense due today"
+            : $"{toNotify.Count} scheduled expenses due today";
+
+        var body = toNotify.Count == 1
+            ? toNotify[0].Description ?? "An expense template is due today."
+            : string.Join(", ", toNotify.Select(t => t.Description ?? "Unnamed").Take(3)) + (toNotify.Count > 3 ? $" +{toNotify.Count - 3} more" : "");
+
+        await pushSender.SendAsync(userId, title, body, "/expense-templates", "expense-template-due");
+
+        foreach (var template in toNotify)
+        {
+            accountDb.ExpenseTemplateNotificationDispatches.Add(new ExpenseTemplateNotificationDispatch
+            {
+                UserId = userId,
+                ExpenseTemplateId = template.Id,
+                Date = today.ToDateTime(TimeOnly.MinValue),
+                CreatedAt = DateTime.UtcNow,
+                SentAt = DateTime.UtcNow
+            });
+        }
+
+        await accountDb.SaveChangesAsync(ct);
+    }
+
+    private static bool IsDueToday(ExpenseTemplateEntity template, DateOnly today)
+    {
+        return template.Period switch
+        {
+            RecurrencePeriod.Monthly => template.DayInPeriod == today.Day,
+            RecurrencePeriod.Yearly => template.DayInPeriod == today.Day && template.MonthInPeriod == today.Month,
+            RecurrencePeriod.Single => template.DueDate.HasValue && DateOnly.FromDateTime(template.DueDate.Value) == today,
+            RecurrencePeriod.XMonths => IsXMonthsDue(template, today),
+            _ => false
+        };
+    }
+
+    private static bool IsXMonthsDue(ExpenseTemplateEntity template, DateOnly today)
+    {
+        if (template.DueDate == null || template.EveryXPeriods == null || template.DayInPeriod == null)
+            return false;
+
+        if (template.DayInPeriod != today.Day)
+            return false;
+
+        var startDate = DateOnly.FromDateTime(template.DueDate.Value);
+        var monthsDiff = (today.Year - startDate.Year) * 12 + (today.Month - startDate.Month);
+
+        return monthsDiff >= 0 && monthsDiff % template.EveryXPeriods.Value == 0;
+    }
+}

--- a/src/Money.Api/Accounts/Models/NotificationOptions.cs
+++ b/src/Money.Api/Accounts/Models/NotificationOptions.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Money.Accounts.Models;
+
+public class NotificationOptions
+{
+    public string Subject { get; set; }
+    public string PublicKey { get; set; }
+    public string PrivateKey { get; set; }
+    public ExpenseTemplateNotificationOptions ExpenseTemplates { get; set; } = new();
+}
+
+public class ExpenseTemplateNotificationOptions
+{
+    public TimeSpan TickInterval { get; set; } = TimeSpan.FromMinutes(15);
+}

--- a/src/Money.Api/Accounts/PushNotificationSender.cs
+++ b/src/Money.Api/Accounts/PushNotificationSender.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Money.Accounts.Models;
+using Neptuo;
+using Neptuo.Activators;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using WebPush;
+
+namespace Money.Accounts;
+
+public class PushNotificationSender
+{
+    private readonly IFactory<AccountContext> dbFactory;
+    private readonly IOptions<NotificationOptions> options;
+    private readonly ILogger<PushNotificationSender> logger;
+
+    public bool IsConfigured => !string.IsNullOrEmpty(options.Value.PublicKey) && !string.IsNullOrEmpty(options.Value.PrivateKey);
+    public string PublicKey => options.Value.PublicKey;
+
+    public PushNotificationSender(IFactory<AccountContext> dbFactory, IOptions<NotificationOptions> options, ILogger<PushNotificationSender> logger)
+    {
+        Ensure.NotNull(dbFactory, "dbFactory");
+        Ensure.NotNull(options, "options");
+        Ensure.NotNull(logger, "logger");
+        this.dbFactory = dbFactory;
+        this.options = options;
+        this.logger = logger;
+    }
+
+    public async Task SendAsync(string userId, string title, string body, string url, string tag)
+    {
+        if (!IsConfigured)
+        {
+            logger.LogWarning("Push notifications are not configured (missing VAPID keys).");
+            return;
+        }
+
+        using var db = dbFactory.Create();
+        var subscriptions = await db.PushSubscriptions
+            .Where(s => s.UserId == userId && s.RevokedAt == null)
+            .ToListAsync();
+
+        if (subscriptions.Count == 0)
+            return;
+
+        var vapidDetails = new VapidDetails(options.Value.Subject, options.Value.PublicKey, options.Value.PrivateKey);
+        var client = new WebPushClient();
+
+        var payload = System.Text.Json.JsonSerializer.Serialize(new { title, body, url, tag });
+
+        foreach (var subscription in subscriptions)
+        {
+            try
+            {
+                var pushSubscription = new WebPush.PushSubscription(subscription.Endpoint, subscription.P256dh, subscription.Auth);
+                await client.SendNotificationAsync(pushSubscription, payload, vapidDetails);
+            }
+            catch (WebPushException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Gone || ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                logger.LogInformation("Push subscription {Endpoint} is gone, revoking.", subscription.Endpoint);
+                subscription.RevokedAt = DateTime.UtcNow;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to send push notification to {Endpoint}.", subscription.Endpoint);
+            }
+        }
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/src/Money.Api/Money.Api.csproj
+++ b/src/Money.Api/Money.Api.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="WebPush" />
 	<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 	<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
 	<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />

--- a/src/Money.Api/Startup.cs
+++ b/src/Money.Api/Startup.cs
@@ -143,6 +143,13 @@ namespace Money
             }
 
             var allowedUserPropertyKeys = Configuration.GetSection("UserProperties").Get<string[]>() ?? new string[0];
+
+            services
+                .Configure<NotificationOptions>(Configuration.GetSection("Notifications"))
+                .AddSingleton(TimeProvider.System)
+                .AddTransient<PushNotificationSender>()
+                .AddHostedService<ExpenseTemplateNotificationBackgroundService>();
+
             Bootstrap.BootstrapTask bootstrapTask = new Bootstrap.BootstrapTask(services, connectionStrings, allowedUserPropertyKeys, ApplyBasePath);
             bootstrapTask.Initialize();
         }

--- a/src/Money.Api/appsettings.json
+++ b/src/Money.Api/appsettings.json
@@ -14,6 +14,14 @@
       "RequireUppercase": false
     }
   },
+  "Notifications": {
+    "Subject": "mailto:notifications@money.neptuo.com",
+    "PublicKey": "",
+    "PrivateKey": "",
+    "ExpenseTemplates": {
+      "TickInterval": "00:15:00"
+    }
+  },
   "UserProperties": [
     "PriceDecimalDigits",
     "DateFormat",

--- a/src/Money.Blazor.Host/MenuItems/MenuItemService.cs
+++ b/src/Money.Blazor.Host/MenuItems/MenuItemService.cs
@@ -168,6 +168,11 @@ namespace Money
                         Url: navigator.UrlUserSettings()
                     ),
                     new(
+                        Text: "Notifications",
+                        Icon: "bell",
+                        Url: navigator.UrlUserNotifications()
+                    ),
+                    new(
                         Text: "Logout",
                         Icon: "sign-out-alt",
                         OnClick: async () => await apiClient.LogoutAsync()

--- a/src/Money.Blazor.Host/Pages/Users/Notifications.razor
+++ b/src/Money.Blazor.Host/Pages/Users/Notifications.razor
@@ -1,0 +1,114 @@
+@page "/user/notifications"
+@attribute [Authorize]
+
+<UserHead />
+
+<div class="container mt-4">
+    <h4>
+        <Icon Identifier="bell" class="me-2" />
+        Notifications
+    </h4>
+
+    @if (IsLoading)
+    {
+        <div class="text-center my-4">
+            <span class="spinner-border spinner-border-sm"></span>
+            Loading...
+        </div>
+    }
+    else if (!IsSupported)
+    {
+        <div class="alert alert-warning mt-3">
+            <Icon Identifier="exclamation-triangle" class="me-1" />
+            Push notifications are not supported in this browser.
+        </div>
+    }
+    else
+    {
+        <div class="card mt-3">
+            <div class="card-body">
+                <div class="form-check form-switch mb-3">
+                    <input class="form-check-input" type="checkbox" id="notificationsEnabled" checked="@IsEnabled" @onchange="OnGlobalToggleChanged" />
+                    <label class="form-check-label" for="notificationsEnabled">
+                        <strong>Enable notifications</strong>
+                    </label>
+                </div>
+
+                @if (IsEnabled)
+                {
+                    <hr />
+
+                    <h5 class="mt-3">
+                        <Icon Identifier="redo" class="me-1" />
+                        Scheduled expenses
+                    </h5>
+
+                    <div class="form-check form-switch mb-3">
+                        <input class="form-check-input" type="checkbox" id="expenseTemplatesEnabled" checked="@ExpenseTemplatesEnabled" @onchange="OnExpenseTemplateToggleChanged" />
+                        <label class="form-check-label" for="expenseTemplatesEnabled">
+                            Notify when expenses are due today
+                        </label>
+                    </div>
+
+                    @if (ExpenseTemplatesEnabled)
+                    {
+                        <div class="row mb-3">
+                            <div class="col-auto">
+                                <label class="form-label">Preferred time</label>
+                                <select class="form-select" value="@PreferredHour" @onchange="OnPreferredHourChanged">
+                                    @for (int h = 0; h < 24; h++)
+                                    {
+                                        <option value="@h">@($"{h:D2}:00")</option>
+                                    }
+                                </select>
+                            </div>
+                            <div class="col-auto">
+                                <label class="form-label">Timezone</label>
+                                <input type="text" class="form-control" value="@TimeZone" readonly />
+                            </div>
+                        </div>
+                    }
+
+                    <hr />
+
+                    <h5 class="mt-3">
+                        <Icon Identifier="mobile-alt" class="me-1" />
+                        This browser
+                    </h5>
+
+                    @if (Permission == "denied")
+                    {
+                        <div class="alert alert-danger">
+                            <Icon Identifier="ban" class="me-1" />
+                            Notifications are blocked by your browser. Please enable them in your browser settings.
+                        </div>
+                    }
+                    else if (HasSubscription)
+                    {
+                        <div class="d-flex align-items-center">
+                            <span class="text-success me-2">
+                                <Icon Identifier="check-circle" />
+                                Subscribed
+                            </span>
+                            <button class="btn btn-outline-danger btn-sm" @onclick="OnUnsubscribe">
+                                Unsubscribe
+                            </button>
+                        </div>
+                    }
+                    else
+                    {
+                        <button class="btn btn-primary" @onclick="OnSubscribe">
+                            <Icon Identifier="bell" class="me-1" />
+                            Enable on this browser
+                        </button>
+                    }
+
+                    @if (StatusMessage != null)
+                    {
+                        <div class="alert alert-info mt-2">@StatusMessage</div>
+                    }
+                }
+            </div>
+        </div>
+    }
+</div>

--- a/src/Money.Blazor.Host/Pages/Users/Notifications.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Users/Notifications.razor.cs
@@ -1,0 +1,153 @@
+using Microsoft.AspNetCore.Components;
+using Money.Accounts.Models;
+using Money.Services;
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Money.Pages.Users;
+
+public partial class Notifications
+{
+    [Inject] protected PushNotificationInterop PushInterop { get; set; }
+    [Inject] protected HttpClient Http { get; set; }
+    [Inject] protected Json Json { get; set; }
+
+    protected bool IsLoading { get; set; } = true;
+    protected bool IsSupported { get; set; }
+    protected bool IsEnabled { get; set; }
+    protected bool ExpenseTemplatesEnabled { get; set; }
+    protected int PreferredHour { get; set; } = 8;
+    protected string TimeZone { get; set; } = "UTC";
+    protected string Permission { get; set; } = "default";
+    protected bool HasSubscription { get; set; }
+    protected string PushPublicKey { get; set; }
+    protected string StatusMessage { get; set; }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            IsSupported = await PushInterop.IsSupportedAsync();
+
+            if (IsSupported)
+            {
+                Permission = await PushInterop.GetPermissionAsync();
+                TimeZone = await PushInterop.GetTimeZoneAsync();
+
+                await LoadSettingsAsync();
+
+                var currentSub = await PushInterop.GetSubscriptionAsync();
+                HasSubscription = currentSub != null;
+            }
+
+            IsLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task LoadSettingsAsync()
+    {
+        try
+        {
+            var response = await Http.GetAsync("/api/notifications");
+            if (response.IsSuccessStatusCode)
+            {
+                var content = await response.Content.ReadAsStringAsync();
+                var settings = Json.Deserialize<NotificationSettingsModel>(content);
+                IsEnabled = settings.IsEnabled;
+                PushPublicKey = settings.PushPublicKey;
+                ExpenseTemplatesEnabled = settings.ExpenseTemplates?.IsEnabled ?? false;
+                PreferredHour = settings.ExpenseTemplates?.PreferredHour ?? 8;
+                if (!string.IsNullOrEmpty(settings.ExpenseTemplates?.TimeZone) && settings.ExpenseTemplates.TimeZone != "UTC")
+                    TimeZone = settings.ExpenseTemplates.TimeZone;
+            }
+        }
+        catch
+        {
+            // Settings not available yet
+        }
+    }
+
+    private async Task OnGlobalToggleChanged(ChangeEventArgs e)
+    {
+        IsEnabled = (bool)e.Value;
+        await SaveGlobalSettingsAsync();
+    }
+
+    private async Task OnExpenseTemplateToggleChanged(ChangeEventArgs e)
+    {
+        ExpenseTemplatesEnabled = (bool)e.Value;
+        await SaveExpenseTemplateSettingsAsync();
+    }
+
+    private async Task OnPreferredHourChanged(ChangeEventArgs e)
+    {
+        PreferredHour = int.Parse(e.Value.ToString());
+        await SaveExpenseTemplateSettingsAsync();
+    }
+
+    private async Task SaveGlobalSettingsAsync()
+    {
+        var payload = Json.Serialize(new { IsEnabled });
+        await Http.PutAsync("/api/notifications", new StringContent(payload, Encoding.UTF8, "text/json"));
+    }
+
+    private async Task SaveExpenseTemplateSettingsAsync()
+    {
+        var payload = Json.Serialize(new { IsEnabled = ExpenseTemplatesEnabled, PreferredHour, TimeZone });
+        await Http.PutAsync("/api/notifications/expense-templates", new StringContent(payload, Encoding.UTF8, "text/json"));
+    }
+
+    private async Task OnSubscribe()
+    {
+        StatusMessage = null;
+        try
+        {
+            if (string.IsNullOrEmpty(PushPublicKey))
+            {
+                StatusMessage = "Push notifications are not configured on the server.";
+                return;
+            }
+
+            var subscription = await PushInterop.SubscribeAsync(PushPublicKey);
+            if (subscription != null)
+            {
+                var payload = Json.Serialize(new { subscription.Endpoint, subscription.P256dh, subscription.Auth });
+                await Http.PostAsync("/api/notifications/subscriptions", new StringContent(payload, Encoding.UTF8, "text/json"));
+                HasSubscription = true;
+                Permission = await PushInterop.GetPermissionAsync();
+                StatusMessage = "Successfully subscribed to notifications.";
+            }
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Failed to subscribe: {ex.Message}";
+        }
+    }
+
+    private async Task OnUnsubscribe()
+    {
+        StatusMessage = null;
+        try
+        {
+            var endpoint = await PushInterop.UnsubscribeAsync();
+            if (endpoint != null)
+            {
+                var payload = Json.Serialize(new { Endpoint = endpoint });
+                var request = new HttpRequestMessage(HttpMethod.Delete, "/api/notifications/subscriptions")
+                {
+                    Content = new StringContent(payload, Encoding.UTF8, "text/json")
+                };
+                await Http.SendAsync(request);
+            }
+            HasSubscription = false;
+            StatusMessage = "Unsubscribed from notifications.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Failed to unsubscribe: {ex.Message}";
+        }
+    }
+}

--- a/src/Money.Blazor.Host/Program.cs
+++ b/src/Money.Blazor.Host/Program.cs
@@ -62,6 +62,7 @@ namespace Money.UI.Blazor
                 .AddTransient<IApiHubState>(provider => provider.GetRequiredService<ApiHubService>())
                 .AddSingleton<ApiVersionChecker>()
                 .AddTransient<Interop>()
+                .AddTransient<PushNotificationInterop>()
                 .AddSingleton<PwaInstallInterop>()
                 .AddTransient<NetworkStateInterop>()
                 .AddSingleton<NetworkState>()

--- a/src/Money.Blazor.Host/Services/NavigatorUrl.cs
+++ b/src/Money.Blazor.Host/Services/NavigatorUrl.cs
@@ -115,6 +115,9 @@ namespace Money.Services
         public string UrlUserSettings()
             => "/user/settings";
 
+        public string UrlUserNotifications()
+            => "/user/notifications";
+
         public string UrlAccountLogin()
             => "/account/login";
 

--- a/src/Money.Blazor.Host/Services/PushNotificationInterop.cs
+++ b/src/Money.Blazor.Host/Services/PushNotificationInterop.cs
@@ -1,0 +1,41 @@
+using Microsoft.JSInterop;
+using Neptuo;
+using System.Threading.Tasks;
+
+namespace Money.Services;
+
+public class PushNotificationInterop
+{
+    private readonly IJSRuntime js;
+
+    public PushNotificationInterop(IJSRuntime js)
+    {
+        Ensure.NotNull(js, "js");
+        this.js = js;
+    }
+
+    public async Task<bool> IsSupportedAsync()
+        => await js.InvokeAsync<bool>("Money.Notifications.isSupported");
+
+    public async Task<string> GetPermissionAsync()
+        => await js.InvokeAsync<string>("Money.Notifications.getPermission");
+
+    public async Task<string> GetTimeZoneAsync()
+        => await js.InvokeAsync<string>("Money.Notifications.getTimeZone");
+
+    public async Task<PushSubscriptionResult> GetSubscriptionAsync()
+        => await js.InvokeAsync<PushSubscriptionResult>("Money.Notifications.getSubscription");
+
+    public async Task<PushSubscriptionResult> SubscribeAsync(string publicKey)
+        => await js.InvokeAsync<PushSubscriptionResult>("Money.Notifications.subscribe", publicKey);
+
+    public async Task<string> UnsubscribeAsync()
+        => await js.InvokeAsync<string>("Money.Notifications.unsubscribe");
+}
+
+public class PushSubscriptionResult
+{
+    public string Endpoint { get; set; }
+    public string P256dh { get; set; }
+    public string Auth { get; set; }
+}

--- a/src/Money.Blazor.Host/wwwroot/js/site.js
+++ b/src/Money.Blazor.Host/wwwroot/js/site.js
@@ -472,3 +472,50 @@ Blazor.start({
         window.localStorage.getItem("allowedLogScopePrefixes") ?? ""
     )
 });
+window.Money = window.Money || {};
+Money.Notifications = {
+    isSupported: function() {
+        return 'serviceWorker' in navigator && 'PushManager' in window && 'Notification' in window;
+    },
+    getPermission: function() {
+        return Notification.permission;
+    },
+    getTimeZone: function() {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    },
+    getSubscription: async function() {
+        const registration = await navigator.serviceWorker.ready;
+        const subscription = await registration.pushManager.getSubscription();
+        if (!subscription) return null;
+        const key = subscription.getKey('p256dh');
+        const auth = subscription.getKey('auth');
+        return {
+            endpoint: subscription.endpoint,
+            p256dh: key ? btoa(String.fromCharCode.apply(null, new Uint8Array(key))) : null,
+            auth: auth ? btoa(String.fromCharCode.apply(null, new Uint8Array(auth))) : null
+        };
+    },
+    subscribe: async function(publicKey) {
+        const registration = await navigator.serviceWorker.ready;
+        const subscription = await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: publicKey
+        });
+        const key = subscription.getKey('p256dh');
+        const auth = subscription.getKey('auth');
+        return {
+            endpoint: subscription.endpoint,
+            p256dh: key ? btoa(String.fromCharCode.apply(null, new Uint8Array(key))) : null,
+            auth: auth ? btoa(String.fromCharCode.apply(null, new Uint8Array(auth))) : null
+        };
+    },
+    unsubscribe: async function() {
+        const registration = await navigator.serviceWorker.ready;
+        const subscription = await registration.pushManager.getSubscription();
+        if (subscription) {
+            await subscription.unsubscribe();
+            return subscription.endpoint;
+        }
+        return null;
+    }
+};

--- a/src/Money.Blazor.Host/wwwroot/service-worker.js
+++ b/src/Money.Blazor.Host/wwwroot/service-worker.js
@@ -4,9 +4,38 @@
 
 self.addEventListener('fetch', () => { });
 self.addEventListener('message', onMessage);
+self.addEventListener('push', event => event.waitUntil(onPush(event)));
+self.addEventListener('notificationclick', event => event.waitUntil(onNotificationClick(event)));
 
 function onMessage(event) {
     if (event.data.action === 'skipWaiting') {
         self.skipWaiting();
+    }
+}
+
+async function onPush(event) {
+    const data = event.data ? event.data.json() : {};
+    const title = data.title || 'Money';
+    const options = {
+        body: data.body || 'You have scheduled expenses due today.',
+        icon: 'images/icon-192x192.png',
+        tag: data.tag || 'money-expense-template',
+        renotify: true,
+        data: { url: data.url || '/expense-templates' }
+    };
+    await self.registration.showNotification(title, options);
+}
+
+async function onNotificationClick(event) {
+    event.notification.close();
+    const url = event.notification.data && event.notification.data.url ? event.notification.data.url : '/';
+    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const client of clients) {
+        if (client.url.includes(url) && 'focus' in client) {
+            return client.focus();
+        }
+    }
+    if (self.clients.openWindow) {
+        return self.clients.openWindow(url);
     }
 }

--- a/src/Money.Blazor.Host/wwwroot/service-worker.published.js
+++ b/src/Money.Blazor.Host/wwwroot/service-worker.published.js
@@ -12,6 +12,35 @@ self.addEventListener('install', event => event.waitUntil(onInstall(event)));
 self.addEventListener('activate', event => event.waitUntil(onActivate(event)));
 self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
 self.addEventListener('message', onMessage);
+self.addEventListener('push', event => event.waitUntil(onPush(event)));
+self.addEventListener('notificationclick', event => event.waitUntil(onNotificationClick(event)));
+
+async function onPush(event) {
+    const data = event.data ? event.data.json() : {};
+    const title = data.title || 'Money';
+    const options = {
+        body: data.body || 'You have scheduled expenses due today.',
+        icon: 'images/icon-192x192.png',
+        tag: data.tag || 'money-expense-template',
+        renotify: true,
+        data: { url: data.url || '/expense-templates' }
+    };
+    await self.registration.showNotification(title, options);
+}
+
+async function onNotificationClick(event) {
+    event.notification.close();
+    const url = event.notification.data && event.notification.data.url ? event.notification.data.url : '/';
+    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const client of clients) {
+        if (client.url.includes(url) && 'focus' in client) {
+            return client.focus();
+        }
+    }
+    if (self.clients.openWindow) {
+        return self.clients.openWindow(url);
+    }
+}
 
 function onMessage(event) {
     if (event.data.action === 'skipWaiting') {


### PR DESCRIPTION
## Summary

Implements Web Push notifications to alert users when scheduled expense templates are due today. Based on the notification pattern from neptuo/Recollections#395.

## API Changes

- **NotificationsController** — REST endpoints for notification settings and push subscriptions
  - `GET /api/notifications` — Get current settings
  - `PUT /api/notifications` — Toggle global notifications
  - `PUT /api/notifications/expense-templates` — Configure expense template notifications (enable, preferred hour, timezone)
  - `POST /api/notifications/subscriptions` — Register browser push subscription
  - `DELETE /api/notifications/subscriptions` — Revoke subscription
- **PushNotificationSender** — WebPush/VAPID-based push delivery with auto-revocation of expired endpoints
- **ExpenseTemplateNotificationBackgroundService** — Background service that ticks every 15min, checks due templates per user's timezone/preferred hour, deduplicates via dispatch table
- **EF Entities** — PushSubscription, UserNotificationSettings, UserNotificationExpenseTemplateSettings, ExpenseTemplateNotificationDispatch (with unique index for dedup)

## Blazor Client Changes

- **Service workers** — Push event handlers for showing notifications + click-to-navigate
- **JS interop** — `Money.Notifications` module (subscribe, unsubscribe, permission check, timezone detection)
- **PushNotificationInterop** — C# wrapper for JS Push API calls
- **Notifications page** (`/user/notifications`) — Settings UI with global toggle, expense template toggle, preferred hour selector, browser subscription management
- **Navigation** — Added to user dropdown menu

## Architecture

Maintains separation between:
- **Accounts layer** — Owns subscriptions, settings, and push delivery
- **Money domain** — Owns "due today" logic (recurrence calculation via ReadModelContext)

## Setup

To enable push notifications, generate VAPID keys and configure in `appsettings.json`:
```
npx web-push generate-vapid-keys
```

Then set `Notifications:PublicKey` and `Notifications:PrivateKey`.

## TODO (follow-up)
- [ ] EF migration (needs to be generated in environment with DB access)
- [ ] Badge icon asset for Android

Closes #617
Closes #672
Closes #673