### PR TITLE
Add loading placeholders to Balances page

### DIFF
--- a/src/Money.Blazor.Host/Components/PeriodSelector.razor.cs
+++ b/src/Money.Blazor.Host/Components/PeriodSelector.razor.cs
@@ -37,6 +37,7 @@ public partial class PeriodSelector<T>
     protected async Task OpenSelectorAsync()
     {
         SelectorModal.Show();
+        Periods = null;
         await LoadAsync();
     }
 }

--- a/src/Money.Blazor.Host/Components/PeriodSelector.razor.cs
+++ b/src/Money.Blazor.Host/Components/PeriodSelector.razor.cs
@@ -36,8 +36,8 @@ public partial class PeriodSelector<T>
 
     protected async Task OpenSelectorAsync()
     {
-        SelectorModal.Show();
         Periods = null;
+        SelectorModal.Show();
         await LoadAsync();
     }
 }

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -46,6 +46,14 @@
                 : "mx-1 text-center"
         )
     }
+    else if (Loading.IsLoading)
+    {
+        <span class="placeholder-glow mx-1">
+            <span class="placeholder col-1"></span>
+            <span class="placeholder col-1 ms-1"></span>
+            <span class="placeholder col-1 ms-1"></span>
+        </span>
+    }
     <EnumSelector Icon="eye" Text="Display" TType="BalanceDisplayType" @bind-Current="@SelectedDisplayType" Changed="StateHasChanged">
         <AfterContent>
             <hr class="dropdown-divider" />

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -5,15 +5,16 @@
 {
     RenderFragment RenderBalanceValue(Price incomes, Price expenses, Price expectedExpenses, string containerCssClass = null, string totalValueCssClass = null)
     {
+        var spacing = string.IsNullOrEmpty(totalValueCssClass) ? "ms-1" : "";
         return
         @<div class="@containerCssClass">
             @if (SelectedDisplayType == BalanceDisplayType.Total)
             {
                 <PriceView TagName="small" CssClass="@($"text-success {totalValueCssClass}")" Value="@incomes" />
-                <PriceView TagName="small" CssClass="@($"text-danger {totalValueCssClass}")" Value="expenses" />
+                <PriceView TagName="small" CssClass="@($"text-danger {spacing} {totalValueCssClass}")" Value="expenses" />
                 @if (expectedExpenses != null)
                 {
-                    <PriceView TagName="small" CssClass="@($"text-danger {totalValueCssClass}")" CssStyle="opacity: .5" Value="expectedExpenses" />
+                    <PriceView TagName="small" CssClass="@($"text-danger {spacing} {totalValueCssClass}")" CssStyle="opacity: .5" Value="expectedExpenses" />
                 }
             }
             else

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -86,8 +86,8 @@
                         </div>
                         <div class="d-none d-lg-block text-center mt-1">
                             <div class="d-none d-lg-block text-center mt-1">
-                                <small class="placeholder d-block col-3 mx-auto mb-1"></small>
-                                <small class="placeholder d-block col-4 mx-auto"></small>
+                                <small class="d-block placeholder">$0.00</small>
+                                <small class="d-block placeholder">$0.00</small>
                             </div>
                             <div class="text-center mt-1">
                                 <span class="d-none d-lg-inline">

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -49,9 +49,7 @@
     else if (Loading.IsLoading)
     {
         <span class="placeholder-glow mx-1">
-            <span class="placeholder col-1"></span>
-            <span class="placeholder col-1 ms-1"></span>
-            <span class="placeholder col-1 ms-1"></span>
+            <span class="placeholder" style="width: 6rem"></span>
         </span>
     }
     <EnumSelector Icon="eye" Text="Display" TType="BalanceDisplayType" @bind-Current="@SelectedDisplayType" Changed="StateHasChanged">

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -82,10 +82,8 @@
                     <div class="p-1">
                         <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
                             <span>@monthName</span>
-                            <span class="placeholder col-2"></span>
                         </div>
                         <div class="d-none d-lg-block text-center mt-1">
-                            <span class="placeholder col-4 d-block mx-auto"></span>
                             <div class="text-center mt-1">
                                 <span class="d-none d-lg-inline">
                                     @monthName
@@ -98,7 +96,7 @@
                     </div>
                     <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
                         <div class="placeholder" style="width: @(incomeHeight)%; height: 10px"></div>
-                        <div class="mt-1 d-flex">
+                        <div class="mt-1">
                             <div class="placeholder" style="width: @(expenseHeight)%; height: 10px"></div>
                         </div>
                     </div>

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -83,6 +83,10 @@
                     <div class="p-1">
                         <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
                             <span>@monthName</span>
+                            <div>
+                                <small class="placeholder">$0.00</small>
+                                <small class="placeholder ms-1">$0.00</small>
+                            </div>
                         </div>
                         <div class="d-none d-lg-block text-center mt-1">
                             <div class="d-none d-lg-block text-center mt-1">

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -10,10 +10,10 @@
             @if (SelectedDisplayType == BalanceDisplayType.Total)
             {
                 <PriceView TagName="small" CssClass="@($"text-success {totalValueCssClass}")" Value="@incomes" />
-                <PriceView TagName="small" CssClass="@($"text-danger ms-1 {totalValueCssClass}")" Value="expenses" />
+                <PriceView TagName="small" CssClass="@($"text-danger {totalValueCssClass}")" Value="expenses" />
                 @if (expectedExpenses != null)
                 {
-                    <PriceView TagName="small" CssClass="@($"text-danger ms-1 {totalValueCssClass}")" CssStyle="opacity: .5" Value="expectedExpenses" />
+                    <PriceView TagName="small" CssClass="@($"text-danger {totalValueCssClass}")" CssStyle="opacity: .5" Value="expectedExpenses" />
                 }
             }
             else
@@ -84,6 +84,10 @@
                             <span>@monthName</span>
                         </div>
                         <div class="d-none d-lg-block text-center mt-1">
+                            <div class="d-none d-lg-block text-center mt-1">
+                                <small class="placeholder d-block col-4 mx-auto"></small>
+                                <small class="placeholder d-block col-4 mx-auto"></small>
+                            </div>
                             <div class="text-center mt-1">
                                 <span class="d-none d-lg-inline">
                                     @monthName

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -34,9 +34,6 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
     <div>
         <PeriodSelector Selected="SelectedPeriod" Previous="PeriodGuesses" ExactGetter="GetYearsAsync" LinkFactory="@(year => Navigator.UrlBalances(year))" />
-        <span class="ps-2">
-            <Loading Context="@Loading" />
-        </span>
     </div>
     @if (TotalIncomes != null && TotalExpenses != null)
     {
@@ -65,30 +62,39 @@
             <div class="row no-gutters @ctx.CssClass" style="min-height: calc(100vh - 402px)">
                 @for (int i = 0; i < 12; i++)
                 {
+                    var month = i + 1;
+                    var monthName = System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.MonthNames[i];
                     var incomeHeight = Random.Shared.Next(20, 90);
                     var expenseHeight = Random.Shared.Next(20, 70);
 
                     <div class="col-12 col-lg-1">
                         <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
-                            <div class="w-50 placeholder bg-success" style="height: @(incomeHeight)%"></div>
+                            <div class="w-50 placeholder" style="height: @(incomeHeight)%"></div>
                             <div class="w-50 h-100 d-flex flex-column justify-content-end">
-                                <div class="w-100 placeholder bg-danger" style="height: @(expenseHeight)%"></div>
+                                <div class="w-100 placeholder" style="height: @(expenseHeight)%"></div>
                             </div>
                         </div>
                         <div class="p-1">
                             <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                                <span class="placeholder col-3"></span>
+                                <span>@monthName</span>
                                 <span class="placeholder col-2"></span>
                             </div>
                             <div class="d-none d-lg-block text-center mt-1">
                                 <span class="placeholder col-4 d-block mx-auto"></span>
-                                <span class="placeholder col-3 d-block mx-auto mt-1"></span>
+                                <div class="text-center mt-1">
+                                    <span class="d-none d-lg-inline">
+                                        @monthName
+                                    </span>
+                                    <span class="d-inline d-lg-none">
+                                        @month.ToString("D2")
+                                    </span>
+                                </div>
                             </div>
                         </div>
                         <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                            <div class="placeholder bg-success" style="width: @(incomeHeight)%; height: 10px"></div>
+                            <div class="placeholder" style="width: @(incomeHeight)%; height: 10px"></div>
                             <div class="mt-1 d-flex">
-                                <div class="placeholder bg-danger" style="width: @(expenseHeight)%; height: 10px"></div>
+                                <div class="placeholder" style="width: @(expenseHeight)%; height: 10px"></div>
                             </div>
                         </div>
                     </div>

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -104,9 +104,9 @@
                         </div>
                     </div>
                     <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                        <div class="placeholder" style="width: @(incomeHeight)%; height: 10px"></div>
-                        <div class="mt-1">
-                            <div class="placeholder" style="width: @(expenseHeight)%; height: 10px"></div>
+                        <div class="bg-secondary" style="width: @(incomeHeight)%; height: 10px; opacity: .5;"></div>
+                        <div class="mt-1 d-flex">
+                            <div class="bg-secondary" style="width: @(expenseHeight)%; height: 10px; opacity: .5;"></div>
                         </div>
                     </div>
                 </div>

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -86,7 +86,7 @@
                         </div>
                         <div class="d-none d-lg-block text-center mt-1">
                             <div class="d-none d-lg-block text-center mt-1">
-                                <small class="placeholder d-block col-4 mx-auto"></small>
+                                <small class="placeholder d-block col-3 mx-auto mb-1"></small>
                                 <small class="placeholder d-block col-4 mx-auto"></small>
                             </div>
                             <div class="text-center mt-1">

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -89,17 +89,10 @@
                             </div>
                         </div>
                         <div class="d-none d-lg-block text-center mt-1">
-                            <div class="d-none d-lg-block text-center mt-1">
-                                <small class="d-block placeholder">$0.00</small>
-                                <small class="d-block placeholder">$0.00</small>
-                            </div>
+                            <small class="d-block placeholder">$0.00</small>
+                            <small class="d-block placeholder">$0.00</small>
                             <div class="text-center mt-1">
-                                <span class="d-none d-lg-inline">
-                                    @monthName
-                                </span>
-                                <span class="d-inline d-lg-none">
-                                    @month.ToString("D2")
-                                </span>
+                                @monthName
                             </div>
                         </div>
                     </div>

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -66,49 +66,47 @@
 
 <Loading Context="@Loading">
     <LoadingContent>
-        <PlaceholderContainer IsActive="true" Context="ctx">
-            <div class="row no-gutters @ctx.CssClass" style="min-height: calc(100vh - 402px)">
-                @for (int i = 0; i < 12; i++)
-                {
-                    var month = i + 1;
-                    var monthName = System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.MonthNames[i];
-                    var incomeHeight = Random.Shared.Next(20, 90);
-                    var expenseHeight = Random.Shared.Next(20, 70);
+        <div class="row no-gutters placeholder-glow" style="min-height: calc(100vh - 402px)">
+            @for (int i = 0; i < 12; i++)
+            {
+                var month = i + 1;
+                var monthName = System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.MonthNames[i];
+                var incomeHeight = Random.Shared.Next(20, 90);
+                var expenseHeight = Random.Shared.Next(20, 70);
 
-                    <div class="col-12 col-lg-1">
-                        <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
-                            <div class="w-50 placeholder" style="height: @(incomeHeight)%"></div>
-                            <div class="w-50 h-100 d-flex flex-column justify-content-end">
-                                <div class="w-100 placeholder" style="height: @(expenseHeight)%"></div>
-                            </div>
+                <div class="col-12 col-lg-1">
+                    <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
+                        <div class="w-50 placeholder" style="height: @(incomeHeight)%"></div>
+                        <div class="w-50 h-100 d-flex flex-column justify-content-end">
+                            <div class="w-100 placeholder" style="height: @(expenseHeight)%"></div>
                         </div>
-                        <div class="p-1">
-                            <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                                <span>@monthName</span>
-                                <span class="placeholder col-2"></span>
-                            </div>
-                            <div class="d-none d-lg-block text-center mt-1">
-                                <span class="placeholder col-4 d-block mx-auto"></span>
-                                <div class="text-center mt-1">
-                                    <span class="d-none d-lg-inline">
-                                        @monthName
-                                    </span>
-                                    <span class="d-inline d-lg-none">
-                                        @month.ToString("D2")
-                                    </span>
-                                </div>
-                            </div>
+                    </div>
+                    <div class="p-1">
+                        <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
+                            <span>@monthName</span>
+                            <span class="placeholder col-2"></span>
                         </div>
-                        <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                            <div class="placeholder" style="width: @(incomeHeight)%; height: 10px"></div>
-                            <div class="mt-1 d-flex">
-                                <div class="placeholder" style="width: @(expenseHeight)%; height: 10px"></div>
+                        <div class="d-none d-lg-block text-center mt-1">
+                            <span class="placeholder col-4 d-block mx-auto"></span>
+                            <div class="text-center mt-1">
+                                <span class="d-none d-lg-inline">
+                                    @monthName
+                                </span>
+                                <span class="d-inline d-lg-none">
+                                    @month.ToString("D2")
+                                </span>
                             </div>
                         </div>
                     </div>
-                }
-            </div>
-        </PlaceholderContainer>
+                    <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
+                        <div class="placeholder" style="width: @(incomeHeight)%; height: 10px"></div>
+                        <div class="mt-1 d-flex">
+                            <div class="placeholder" style="width: @(expenseHeight)%; height: 10px"></div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
     </LoadingContent>
     <ChildContent>
         @if (Models != null)

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -59,62 +59,98 @@
     </EnumSelector>
 </div>
 
-@if (Models == null)
-{
-    <Loading />
-}
-else
-{
-    <div class="row no-gutters" style="min-height: calc(100vh - 402px)">
-        @foreach (var model in Models)
-        {
-            var expenseSize = MaxAmount == 0 ? 0 : model.ExpenseSummary.Value / MaxAmount * 100;
-            var expectedExpenseSize = MaxAmount == 0 ? 0 : (model.ExpectedExpenseSummary?.Value ?? 0) / MaxAmount * 100;
-            var incomeSize = MaxAmount == 0 ? 0 : model.IncomeSummary.Value / MaxAmount * 100;
+<Loading Context="@Loading">
+    <LoadingContent>
+        <PlaceholderContainer IsActive="true" Context="ctx">
+            <div class="row no-gutters @ctx.CssClass" style="min-height: calc(100vh - 402px)">
+                @for (int i = 0; i < 12; i++)
+                {
+                    var incomeHeight = Random.Shared.Next(20, 90);
+                    var expenseHeight = Random.Shared.Next(20, 70);
 
-            <div class="col-12 col-lg-1 @(model > AppDateTime.Today ? "text-muted" : String.Empty)">
-                <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
-                    <div class="w-50 bg-success" style="height: @incomeSize%"></div>
-                    <div class="w-50 h-100 d-flex flex-column justify-content-end">
-                        <div class="w-100 bg-danger" style="height: @expectedExpenseSize%; opacity: .5;"></div>
-                        <div class="w-100 bg-danger" style="height: @expenseSize%;"></div>
-                    </div>
-                </div>
-                <div class="p-1">
-                    <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                        <a href="@Navigator.UrlOverview(model)">
-                            @model.ToMonthString()
-                        </a>
-                        @RenderBalanceValue(model.IncomeSummary, model.ExpenseSummary, model.ExpectedExpenseSummary)
-                    </div>
-                    <div class="d-none d-lg-block text-center mt-1">
-                        @RenderBalanceValue(
-                            model.IncomeSummary, 
-                            model.ExpenseSummary, 
-                            model.ExpectedExpenseSummary, 
-                            "d-none d-lg-block text-center mt-1", 
-                            "d-block"
-                        )
-                        <div class="text-center mt-1">
-                            <a href="@Navigator.UrlOverview(model)">
-                                <span class="d-none d-lg-inline">
-                                    @model.ToMonthString()
-                                </span>
-                                <span class="d-inline d-lg-none">
-                                    @model.Month.ToString("D2")
-                                </span>
-                            </a>
+                    <div class="col-12 col-lg-1">
+                        <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
+                            <div class="w-50 placeholder bg-success" style="height: @(incomeHeight)%"></div>
+                            <div class="w-50 h-100 d-flex flex-column justify-content-end">
+                                <div class="w-100 placeholder bg-danger" style="height: @(expenseHeight)%"></div>
+                            </div>
+                        </div>
+                        <div class="p-1">
+                            <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
+                                <span class="placeholder col-3"></span>
+                                <span class="placeholder col-2"></span>
+                            </div>
+                            <div class="d-none d-lg-block text-center mt-1">
+                                <span class="placeholder col-4 d-block mx-auto"></span>
+                                <span class="placeholder col-3 d-block mx-auto mt-1"></span>
+                            </div>
+                        </div>
+                        <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
+                            <div class="placeholder bg-success" style="width: @(incomeHeight)%; height: 10px"></div>
+                            <div class="mt-1 d-flex">
+                                <div class="placeholder bg-danger" style="width: @(expenseHeight)%; height: 10px"></div>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                    <div class="bg-success" style="width: @incomeSize%; height: 10px"></div>
-                    <div class="mt-1 d-flex">
-                        <div class="bg-danger" style="width: @expenseSize%; height: 10px"></div>
-                        <div class="bg-danger" style="width: @expectedExpenseSize%; height: 10px; opacity: .5;"></div>
+                }
+            </div>
+        </PlaceholderContainer>
+    </LoadingContent>
+    <ChildContent>
+        @if (Models != null)
+        {
+            <div class="row no-gutters" style="min-height: calc(100vh - 402px)">
+                @foreach (var model in Models)
+                {
+                    var expenseSize = MaxAmount == 0 ? 0 : model.ExpenseSummary.Value / MaxAmount * 100;
+                    var expectedExpenseSize = MaxAmount == 0 ? 0 : (model.ExpectedExpenseSummary?.Value ?? 0) / MaxAmount * 100;
+                    var incomeSize = MaxAmount == 0 ? 0 : model.IncomeSummary.Value / MaxAmount * 100;
+
+                    <div class="col-12 col-lg-1 @(model > AppDateTime.Today ? "text-muted" : String.Empty)">
+                        <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
+                            <div class="w-50 bg-success" style="height: @incomeSize%"></div>
+                            <div class="w-50 h-100 d-flex flex-column justify-content-end">
+                                <div class="w-100 bg-danger" style="height: @expectedExpenseSize%; opacity: .5;"></div>
+                                <div class="w-100 bg-danger" style="height: @expenseSize%;"></div>
+                            </div>
+                        </div>
+                        <div class="p-1">
+                            <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
+                                <a href="@Navigator.UrlOverview(model)">
+                                    @model.ToMonthString()
+                                </a>
+                                @RenderBalanceValue(model.IncomeSummary, model.ExpenseSummary, model.ExpectedExpenseSummary)
+                            </div>
+                            <div class="d-none d-lg-block text-center mt-1">
+                                @RenderBalanceValue(
+                                    model.IncomeSummary, 
+                                    model.ExpenseSummary, 
+                                    model.ExpectedExpenseSummary, 
+                                    "d-none d-lg-block text-center mt-1", 
+                                    "d-block"
+                                )
+                                <div class="text-center mt-1">
+                                    <a href="@Navigator.UrlOverview(model)">
+                                        <span class="d-none d-lg-inline">
+                                            @model.ToMonthString()
+                                        </span>
+                                        <span class="d-inline d-lg-none">
+                                            @model.Month.ToString("D2")
+                                        </span>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
+                            <div class="bg-success" style="width: @incomeSize%; height: 10px"></div>
+                            <div class="mt-1 d-flex">
+                                <div class="bg-danger" style="width: @expenseSize%; height: 10px"></div>
+                                <div class="bg-danger" style="width: @expectedExpenseSize%; height: 10px; opacity: .5;"></div>
+                            </div>
+                        </div>
                     </div>
-                </div>
+                }
             </div>
         }
-    </div>
-}
+    </ChildContent>
+</Loading>

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
@@ -79,7 +79,7 @@ public partial class BalancesMonth(
             string defaultCurrency = await Queries.QueryAsync(new FindCurrencyDefault());
             var models = await Queries.QueryAsync(new ListMonthBalance(SelectedPeriod, includeExpectedExpenses: IncludeExpectedExpenses));
 
-            MaxAmount = models.Count > 0 ? models.Max(m => Math.Max(m.IncomeSummary.Value, m.ExpenseSummary.Value + m.ExpectedExpenseSummary?.Value ?? 0)) : 0;
+            MaxAmount = models.Count > 0 ? models.Max(m => Math.Max(m.IncomeSummary.Value, m.ExpenseSummary.Value + (m.ExpectedExpenseSummary?.Value ?? 0))) : 0;
             Models = [];
             TotalExpenses = Price.Zero(defaultCurrency);
             TotalIncomes = Price.Zero(defaultCurrency);

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
@@ -76,6 +76,10 @@ public partial class BalancesMonth(
     {
         using (Loading.Start())
         {
+            TotalIncomes = null;
+            TotalExpenses = null;
+            TotalExpectedExpenses = null;
+
             string defaultCurrency = await Queries.QueryAsync(new FindCurrencyDefault());
             var models = await Queries.QueryAsync(new ListMonthBalance(SelectedPeriod, includeExpectedExpenses: IncludeExpectedExpenses));
 


### PR DESCRIPTION
## Motivation

When navigating to or reloading the Balances page, users see a blank area or generic "Loading..." text while data is fetched. This creates a jarring experience, especially on slower connections. The rest of the app already uses a placeholder/skeleton pattern for loading states.

## Approach

Replace the simple loading indicator with animated skeleton placeholders that match the exact layout of the final content -- both on desktop (vertical bar chart) and mobile (horizontal bars with values). This eliminates layout shifts when data arrives.

Key decisions:

- **Gray bars with `placeholder-glow` animation** instead of colored bars, following Bootstrap's placeholder conventions
- **Month names shown immediately** since they're static and don't depend on data
- **Value placeholders use identical HTML structure** (`<small>` tags with dummy `$0.00` text) so they occupy the exact same space as real values
- **Mobile bars use `bg-secondary`** instead of Bootstrap's `.placeholder` class, which enforces `min-height: 1em` and would make bars taller than the real 10px ones
- **Summary totals** at the top show a single placeholder block while loading, with stale values cleared on reload
- **Period selector** clears cached items when reopened so only placeholders show during fetch

## Bug fix included

Fixed a pre-existing operator precedence bug in `MaxAmount` calculation where `expense + expected?.Value ?? 0` evaluated as `(expense + null) ?? 0` instead of `expense + (expected?.Value ?? 0)`, causing all bars to render at 0% height when expected expenses were null.

Fixes: #580