### PR TITLE
Consolidate category icon list: fix duplicate and add common icons

### DIFF
--- a/src/Money.Blazor.Host/Models/IconCollection.cs
+++ b/src/Money.Blazor.Host/Models/IconCollection.cs
@@ -125,7 +125,7 @@ namespace Money.Models
             Add("⚕");
             Add("🏥");
             Add("✈️");
-            Add("☕");
+            Add("☕️");
             Add("🍺");
             Add("👕");
             Add("🎓");

--- a/src/Money.Blazor.Host/Models/IconCollection.cs
+++ b/src/Money.Blazor.Host/Models/IconCollection.cs
@@ -124,6 +124,28 @@ namespace Money.Models
             Add("💊");
             Add("⚕");
             Add("🏥");
+            Add("✈️");
+            Add("☕");
+            Add("🍺");
+            Add("👕");
+            Add("🎓");
+            Add("📚");
+            Add("🎬");
+            Add("💻");
+            Add("📦");
+            Add("🏋️");
+            Add("💇");
+            Add("🐾");
+            Add("👶");
+            Add("🎁");
+            Add("🔌");
+            Add("💧");
+            Add("🌐");
+            Add("🧹");
+            Add("🪴");
+            Add("🛍️");
+            Add("🎟️");
+            Add("🚕");
         }
     }
 }

--- a/src/Money.Blazor.Host/Models/IconCollection.cs
+++ b/src/Money.Blazor.Host/Models/IconCollection.cs
@@ -112,7 +112,6 @@ namespace Money.Models
             Add("🛀");
             Add("🎨");
             Add("🖌");
-            Add("🔨");
             Add("🧷");
             Add("💎");
             Add("💍");


### PR DESCRIPTION
The category icon picker had a duplicate hammer emoji and was missing icons for many common expense categories.

**Changes:**

- Removed the duplicate hammer icon (appeared twice in `IconCollection.cs`)
- Added 22 new icons covering everyday budget categories: travel, coffee, drinks, clothing, education, books, cinema, laptop, packages, gym, haircut, pets, kids, gifts, electricity, water, internet, cleaning, garden, shopping, events, and taxi

This gives users a broader set of recognizable icons when organizing their expense and income categories.