### PR TITLE
Show placeholder skeletons during data loading in MonthlyChecklist

### DIFF
--- a/src/Money.Blazor.Host/MockData.cs
+++ b/src/Money.Blazor.Host/MockData.cs
@@ -39,6 +39,16 @@ internal class MockData
         4
     );
 
+    public static readonly ExpenseChecklistModel ExpenseChecklistModel = new ExpenseChecklistModel(
+        KeyFactory.Create(typeof(ExpenseTemplate)),
+        KeyFactory.Empty(typeof(Outcome)),
+        new Price(1, "USD"),
+        AppDateTime.Today,
+        KeyFactory.Create(typeof(Category)),
+        string.Empty,
+        false
+    );
+
     public static T Get<T>()
     {
         if (typeof(T) == typeof(IncomeOverviewModel))
@@ -55,6 +65,9 @@ internal class MockData
 
         if (typeof(T) == typeof(MonthModel))
             return (T)(object)MonthModel;
+
+        if (typeof(T) == typeof(ExpenseChecklistModel))
+            return (T)(object)ExpenseChecklistModel;
 
         throw Ensure.Exception.NotSupported($"The type '{typeof(T).FullName}' is not supported.");
     }

--- a/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
+++ b/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
@@ -17,42 +17,44 @@
         </li>
     </ul>
 
-    <Loading Context="@Loading">
-        @if (Models.Count == 0)
-        {
-            <Alert Title="No data." Message="Let's add some recurring expense templates." Mode="@AlertMode.Warning" />
-        }
-        else
-        {
-            <div class="cards">
-                <ExpenseCardContext>
-                    @foreach (var model in Models.OrderBy(m => m.When))
+    <div class="cards">
+        <ExpenseCardContext>
+            <AutoLoadListView
+                Items="@Models"
+                PlaceholderCount="@PlaceholderCount"
+                LoadingContext="@Loading"
+                NoDataTitle="No data."
+                NoDataMessage="Let's add some recurring expense templates."
+                Context="item"
+            >
+                @{
+                    var model = item.Model;
+                    var isCreated = !model.ExpenseKey.IsEmpty;
+                    var clickHandler = () => 
                     {
-                        var isCreated = !model.ExpenseKey.IsEmpty;
-                        var clickHandler = () => 
-                        {
-                            if (isCreated)
-                                return;
+                        if (isCreated)
+                            return;
 
-                            var today = AppDateTime.Today;
-                            var isCurrentMonth = SelectedPeriod.Year == today.Year && SelectedPeriod.Month == today.Month;
-                            DateTime? expectedWhen = isCurrentMonth ? null : model.When;
-                            Navigator.OpenExpenseCreate(model.Amount, model.Description, model.CategoryKey, today, model.IsFixed, expectedWhen);
-                        };
-                        var rowCssClass = $"row align-items-center {(!isCreated ? "cursor-pointer" : "")}";
-                        var iconCssClass = $"h1 {(isCreated ? "text-success" : "")} m-0";
+                        var today = AppDateTime.Today;
+                        var isCurrentMonth = SelectedPeriod.Year == today.Year && SelectedPeriod.Month == today.Month;
+                        DateTime? expectedWhen = isCurrentMonth ? null : model.When;
+                        Navigator.OpenExpenseCreate(model.Amount, model.Description, model.CategoryKey, today, model.IsFixed, expectedWhen);
+                    };
+                    var rowCssClass = $"row align-items-center {(!isCreated ? "cursor-pointer" : "")}";
+                    var iconCssClass = $"h1 {(isCreated ? "text-success" : "")} m-0";
+                }
 
-                        <div class="@rowCssClass" @onclick="clickHandler">
-                            <div class="col-auto pe-1">
-                                <Icon Prefix="far" Identifier="@(isCreated ? "check-square" : "square")" class="@iconCssClass" />
-                            </div>
-                            <div class="col">
-                                <ExpenseCard Model="@model" CssClass="@(isCreated ? "checklist-completed" : "")" AmountCssClass="@(isCreated ? "text-decoration-line-through" : "")" />
-                            </div>
-                        </div>
-                    }
-                </ExpenseCardContext>
-            </div>
-        }
-    </Loading>
+                <div class="@rowCssClass" @onclick="clickHandler">
+                    <div class="col-auto pe-1">
+                        <Placeholder>
+                            <Icon Prefix="far" Identifier="@(isCreated ? "check-square" : "square")" class="@iconCssClass" />
+                        </Placeholder>
+                    </div>
+                    <div class="col">
+                        <ExpenseCard Model="@model" CssClass="@(item.Placeholder != null ? item.Placeholder.CssClass : (isCreated ? "checklist-completed" : ""))" AmountCssClass="@(isCreated ? "text-decoration-line-through" : "")" />
+                    </div>
+                </div>
+            </AutoLoadListView>
+        </ExpenseCardContext>
+    </div>
 </div>

--- a/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
+++ b/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor
@@ -30,7 +30,8 @@
                 @{
                     var model = item.Model;
                     var isCreated = !model.ExpenseKey.IsEmpty;
-                    var clickHandler = () => 
+                    var isPlaceholder = item.Placeholder != null;
+                    Action clickHandler = isPlaceholder ? () => { } : () => 
                     {
                         if (isCreated)
                             return;
@@ -40,7 +41,7 @@
                         DateTime? expectedWhen = isCurrentMonth ? null : model.When;
                         Navigator.OpenExpenseCreate(model.Amount, model.Description, model.CategoryKey, today, model.IsFixed, expectedWhen);
                     };
-                    var rowCssClass = $"row align-items-center {(!isCreated ? "cursor-pointer" : "")}";
+                    var rowCssClass = $"row align-items-center {(!isCreated && !isPlaceholder ? "cursor-pointer" : "")}";
                     var iconCssClass = $"h1 {(isCreated ? "text-success" : "")} m-0";
                 }
 

--- a/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor.cs
@@ -69,7 +69,7 @@ public partial class ExpenseChecklistMonth(
 
     private async Task LoadDataAsync()
     {
-        PlaceholderCount = Models?.Count;
+        PlaceholderCount = Models?.Count > 0 ? Models.Count : null;
         Models = null;
         StateHasChanged();
 

--- a/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/ExpenseChecklistMonth.razor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Money.Events;
@@ -36,7 +37,8 @@ public partial class ExpenseChecklistMonth(
     public int Month { get; set; }
 
     protected MonthModel SelectedPeriod { get; set; }
-    protected List<ExpenseChecklistModel> Models { get; set; } = new();
+    protected IReadOnlyCollection<ExpenseChecklistModel> Models { get; set; }
+    protected int? PlaceholderCount { get; set; }
     protected LoadingContext Loading { get; set; } = new();
 
     protected override async Task OnInitializedAsync()
@@ -67,11 +69,14 @@ public partial class ExpenseChecklistMonth(
 
     private async Task LoadDataAsync()
     {
+        PlaceholderCount = Models?.Count;
+        Models = null;
+        StateHasChanged();
+
         using (Loading.Start())
         {
             var data = await Queries.QueryAsync(new ListMonthExpenseChecklist(SelectedPeriod));
-            Models.Clear();
-            Models.AddRange(data);
+            Models = data.OrderBy(m => m.When).ToList();
         }
     }
 


### PR DESCRIPTION
When the expense checklist page reloads data (navigating between months or pull-to-refresh), it previously showed a generic "Loading..." text. This caused a jarring layout shift and lost the user's scroll position.

This PR replaces the `<Loading>` wrapper with the existing `AutoLoadListView` component pattern (already used on the Overview page). On reload, the previous item count is captured, existing items are cleared, and the same number of skeleton placeholder rows are rendered in their place -- preserving scroll position for free since the DOM structure stays the same size.

Key changes:
- `ExpenseChecklistMonth.razor` -- switched to `AutoLoadListView` with placeholder-enabled row template
- `ExpenseChecklistMonth.razor.cs` -- clear items before reload with `StateHasChanged()` so only placeholders show; track previous count via `PlaceholderCount`
- `MockData.cs` -- added `ExpenseChecklistModel` mock for the placeholder system

Fixes: #583