### PR TITLE
Refactor Balances page to use PlaceholderContainer pattern

### DIFF
--- a/src/Money.Blazor.Host/MockData.cs
+++ b/src/Money.Blazor.Host/MockData.cs
@@ -30,6 +30,13 @@ internal class MockData
         0
     );
 
+    public static readonly MonthBalanceModel MonthBalanceModel = new MonthBalanceModel(
+        2020,
+        1,
+        new Price(1, "USD"),
+        new Price(1, "USD")
+    );
+
     public static readonly YearModel YearModel = new YearModel(
         2020
     );
@@ -49,6 +56,9 @@ internal class MockData
 
         if (typeof(T) == typeof(ExpenseTemplateCalendarMonthModel))
             return (T)(object)ExpenseTemplateCalendarMonthModel;
+
+        if (typeof(T) == typeof(MonthBalanceModel))
+            return (T)(object)MonthBalanceModel;
 
         if (typeof(T) == typeof(YearModel))
             return (T)(object)YearModel;

--- a/src/Money.Blazor.Host/MockData.cs
+++ b/src/Money.Blazor.Host/MockData.cs
@@ -30,13 +30,6 @@ internal class MockData
         0
     );
 
-    public static readonly MonthBalanceModel MonthBalanceModel = new MonthBalanceModel(
-        2020,
-        1,
-        new Price(1, "USD"),
-        new Price(1, "USD")
-    );
-
     public static readonly YearModel YearModel = new YearModel(
         2020
     );
@@ -56,9 +49,6 @@ internal class MockData
 
         if (typeof(T) == typeof(ExpenseTemplateCalendarMonthModel))
             return (T)(object)ExpenseTemplateCalendarMonthModel;
-
-        if (typeof(T) == typeof(MonthBalanceModel))
-            return (T)(object)MonthBalanceModel;
 
         if (typeof(T) == typeof(YearModel))
             return (T)(object)YearModel;

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -63,117 +63,108 @@
     </EnumSelector>
 </div>
 
-<div class="row no-gutters" style="min-height: calc(100vh - 402px)">
-    <AutoLoadListView
-        Items="@Models"
-        LoadingContext="@Loading"
-        Context="item"
-        PlaceholderCount="12"
-        NoDataTitle="No data."
-    >
-        @{
-            var expenseSize = MaxAmount == 0 ? 0 : item.Model.ExpenseSummary.Value / MaxAmount * 100;
-            var expectedExpenseSize = MaxAmount == 0 ? 0 : (item.Model.ExpectedExpenseSummary?.Value ?? 0) / MaxAmount * 100;
-            var incomeSize = MaxAmount == 0 ? 0 : item.Model.IncomeSummary.Value / MaxAmount * 100;
-        }
+<PlaceholderContainer IsActive="@Loading.IsLoading" Context="ctx">
+    <div class="row no-gutters @ctx.CssClass" style="min-height: calc(100vh - 402px)">
+        @if (Models != null)
+        {
+            @foreach (var model in Models)
+            {
+                var expenseSize = MaxAmount == 0 ? 0 : model.ExpenseSummary.Value / MaxAmount * 100;
+                var expectedExpenseSize = MaxAmount == 0 ? 0 : (model.ExpectedExpenseSummary?.Value ?? 0) / MaxAmount * 100;
+                var incomeSize = MaxAmount == 0 ? 0 : model.IncomeSummary.Value / MaxAmount * 100;
 
-        <div class="col-12 col-lg-1 @item.Placeholder?.CssClass @(item.Placeholder == null && item.Model > AppDateTime.Today ? "text-muted" : String.Empty)">
-            <Placeholder>
-                <PlaceholderContent>
-                    @{
-                        var placeholderIncomeHeight = Random.Shared.Next(20, 90);
-                        var placeholderExpenseHeight = Random.Shared.Next(20, 70);
-                    }
-                    <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
-                        <div class="w-50 placeholder" style="height: @(placeholderIncomeHeight)%"></div>
-                        <div class="w-50 h-100 d-flex flex-column justify-content-end">
-                            <div class="w-100 placeholder" style="height: @(placeholderExpenseHeight)%"></div>
-                        </div>
-                    </div>
-                </PlaceholderContent>
-                <ChildContent>
-                    <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
-                        <div class="w-50 bg-success" style="height: @incomeSize%"></div>
-                        <div class="w-50 h-100 d-flex flex-column justify-content-end">
-                            <div class="w-100 bg-danger" style="height: @expectedExpenseSize%; opacity: .5;"></div>
-                            <div class="w-100 bg-danger" style="height: @expenseSize%;"></div>
-                        </div>
-                    </div>
-                </ChildContent>
-            </Placeholder>
-            <div class="p-1">
-                <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                    <Placeholder WordMinCount="1" WordMaxCount="1" WordMinLength="5" WordMaxLength="9">
-                        <a href="@Navigator.UrlOverview(item.Model)">
-                            @item.Model.ToMonthString()
-                        </a>
-                    </Placeholder>
+                <div class="col-12 col-lg-1 @(model > AppDateTime.Today ? "text-muted" : String.Empty)">
                     <Placeholder>
                         <PlaceholderContent>
-                            <div>
-                                <small class="placeholder">$0.00</small>
-                                <small class="placeholder ms-1">$0.00</small>
+                            @{
+                                var placeholderIncomeHeight = Random.Shared.Next(20, 90);
+                                var placeholderExpenseHeight = Random.Shared.Next(20, 70);
+                            }
+                            <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
+                                <div class="w-50 placeholder" style="height: @(placeholderIncomeHeight)%"></div>
+                                <div class="w-50 h-100 d-flex flex-column justify-content-end">
+                                    <div class="w-100 placeholder" style="height: @(placeholderExpenseHeight)%"></div>
+                                </div>
                             </div>
                         </PlaceholderContent>
                         <ChildContent>
-                            @RenderBalanceValue(item.Model.IncomeSummary, item.Model.ExpenseSummary, item.Model.ExpectedExpenseSummary)
+                            <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
+                                <div class="w-50 bg-success" style="height: @incomeSize%"></div>
+                                <div class="w-50 h-100 d-flex flex-column justify-content-end">
+                                    <div class="w-100 bg-danger" style="height: @expectedExpenseSize%; opacity: .5;"></div>
+                                    <div class="w-100 bg-danger" style="height: @expenseSize%;"></div>
+                                </div>
+                            </div>
                         </ChildContent>
                     </Placeholder>
-                </div>
-                <div class="d-none d-lg-block text-center mt-1">
-                    <Placeholder>
-                        <PlaceholderContent>
-                            <small class="d-block placeholder">$0.00</small>
-                            <small class="d-block placeholder">$0.00</small>
+                    <div class="p-1">
+                        <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
+                            <span>@model.ToMonthString()</span>
+                            <Placeholder>
+                                <PlaceholderContent>
+                                    <div>
+                                        <small class="placeholder">$0.00</small>
+                                        <small class="placeholder ms-1">$0.00</small>
+                                    </div>
+                                </PlaceholderContent>
+                                <ChildContent>
+                                    @RenderBalanceValue(model.IncomeSummary, model.ExpenseSummary, model.ExpectedExpenseSummary)
+                                </ChildContent>
+                            </Placeholder>
+                        </div>
+                        <div class="d-none d-lg-block text-center mt-1">
+                            <Placeholder>
+                                <PlaceholderContent>
+                                    <small class="d-block placeholder">$0.00</small>
+                                    <small class="d-block placeholder">$0.00</small>
+                                </PlaceholderContent>
+                                <ChildContent>
+                                    @RenderBalanceValue(
+                                        model.IncomeSummary, 
+                                        model.ExpenseSummary, 
+                                        model.ExpectedExpenseSummary, 
+                                        "d-none d-lg-block text-center mt-1", 
+                                        "d-block"
+                                    )
+                                </ChildContent>
+                            </Placeholder>
                             <div class="text-center mt-1">
-                                <span class="placeholder col-6"></span>
-                            </div>
-                        </PlaceholderContent>
-                        <ChildContent>
-                            @RenderBalanceValue(
-                                item.Model.IncomeSummary, 
-                                item.Model.ExpenseSummary, 
-                                item.Model.ExpectedExpenseSummary, 
-                                "d-none d-lg-block text-center mt-1", 
-                                "d-block"
-                            )
-                            <div class="text-center mt-1">
-                                <a href="@Navigator.UrlOverview(item.Model)">
+                                <a href="@Navigator.UrlOverview(model)">
                                     <span class="d-none d-lg-inline">
-                                        @item.Model.ToMonthString()
+                                        @model.ToMonthString()
                                     </span>
                                     <span class="d-inline d-lg-none">
-                                        @item.Model.Month.ToString("D2")
+                                        @model.Month.ToString("D2")
                                     </span>
                                 </a>
                             </div>
+                        </div>
+                    </div>
+                    <Placeholder>
+                        <PlaceholderContent>
+                            @{
+                                var placeholderMobileIncomeWidth = Random.Shared.Next(20, 90);
+                                var placeholderMobileExpenseWidth = Random.Shared.Next(20, 70);
+                            }
+                            <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
+                                <div class="bg-secondary" style="width: @(placeholderMobileIncomeWidth)%; height: 10px; opacity: .5;"></div>
+                                <div class="mt-1 d-flex">
+                                    <div class="bg-secondary" style="width: @(placeholderMobileExpenseWidth)%; height: 10px; opacity: .5;"></div>
+                                </div>
+                            </div>
+                        </PlaceholderContent>
+                        <ChildContent>
+                            <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
+                                <div class="bg-success" style="width: @incomeSize%; height: 10px"></div>
+                                <div class="mt-1 d-flex">
+                                    <div class="bg-danger" style="width: @expenseSize%; height: 10px"></div>
+                                    <div class="bg-danger" style="width: @expectedExpenseSize%; height: 10px; opacity: .5;"></div>
+                                </div>
+                            </div>
                         </ChildContent>
                     </Placeholder>
                 </div>
-            </div>
-            <Placeholder>
-                <PlaceholderContent>
-                    @{
-                        var placeholderMobileIncomeWidth = Random.Shared.Next(20, 90);
-                        var placeholderMobileExpenseWidth = Random.Shared.Next(20, 70);
-                    }
-                    <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                        <div class="bg-secondary" style="width: @(placeholderMobileIncomeWidth)%; height: 10px; opacity: .5;"></div>
-                        <div class="mt-1 d-flex">
-                            <div class="bg-secondary" style="width: @(placeholderMobileExpenseWidth)%; height: 10px; opacity: .5;"></div>
-                        </div>
-                    </div>
-                </PlaceholderContent>
-                <ChildContent>
-                    <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                        <div class="bg-success" style="width: @incomeSize%; height: 10px"></div>
-                        <div class="mt-1 d-flex">
-                            <div class="bg-danger" style="width: @expenseSize%; height: 10px"></div>
-                            <div class="bg-danger" style="width: @expectedExpenseSize%; height: 10px; opacity: .5;"></div>
-                        </div>
-                    </div>
-                </ChildContent>
-            </Placeholder>
-        </div>
-    </AutoLoadListView>
-</div>
+            }
+        }
+    </div>
+</PlaceholderContainer>

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -63,104 +63,117 @@
     </EnumSelector>
 </div>
 
-<Loading Context="@Loading">
-    <LoadingContent>
-        <div class="row no-gutters placeholder-glow" style="min-height: calc(100vh - 402px)">
-            @for (int i = 0; i < 12; i++)
-            {
-                var month = i + 1;
-                var monthName = System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.MonthNames[i];
-                var incomeHeight = Random.Shared.Next(20, 90);
-                var expenseHeight = Random.Shared.Next(20, 70);
+<div class="row no-gutters" style="min-height: calc(100vh - 402px)">
+    <AutoLoadListView
+        Items="@Models"
+        LoadingContext="@Loading"
+        Context="item"
+        PlaceholderCount="12"
+        NoDataTitle="No data."
+    >
+        @{
+            var expenseSize = MaxAmount == 0 ? 0 : item.Model.ExpenseSummary.Value / MaxAmount * 100;
+            var expectedExpenseSize = MaxAmount == 0 ? 0 : (item.Model.ExpectedExpenseSummary?.Value ?? 0) / MaxAmount * 100;
+            var incomeSize = MaxAmount == 0 ? 0 : item.Model.IncomeSummary.Value / MaxAmount * 100;
+        }
 
-                <div class="col-12 col-lg-1">
+        <div class="col-12 col-lg-1 @item.Placeholder?.CssClass @(item.Placeholder == null && item.Model > AppDateTime.Today ? "text-muted" : String.Empty)">
+            <Placeholder>
+                <PlaceholderContent>
+                    @{
+                        var placeholderIncomeHeight = Random.Shared.Next(20, 90);
+                        var placeholderExpenseHeight = Random.Shared.Next(20, 70);
+                    }
                     <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
-                        <div class="w-50 placeholder" style="height: @(incomeHeight)%"></div>
+                        <div class="w-50 placeholder" style="height: @(placeholderIncomeHeight)%"></div>
                         <div class="w-50 h-100 d-flex flex-column justify-content-end">
-                            <div class="w-100 placeholder" style="height: @(expenseHeight)%"></div>
+                            <div class="w-100 placeholder" style="height: @(placeholderExpenseHeight)%"></div>
                         </div>
                     </div>
-                    <div class="p-1">
-                        <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                            <span>@monthName</span>
+                </PlaceholderContent>
+                <ChildContent>
+                    <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
+                        <div class="w-50 bg-success" style="height: @incomeSize%"></div>
+                        <div class="w-50 h-100 d-flex flex-column justify-content-end">
+                            <div class="w-100 bg-danger" style="height: @expectedExpenseSize%; opacity: .5;"></div>
+                            <div class="w-100 bg-danger" style="height: @expenseSize%;"></div>
+                        </div>
+                    </div>
+                </ChildContent>
+            </Placeholder>
+            <div class="p-1">
+                <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
+                    <Placeholder WordMinCount="1" WordMaxCount="1" WordMinLength="5" WordMaxLength="9">
+                        <a href="@Navigator.UrlOverview(item.Model)">
+                            @item.Model.ToMonthString()
+                        </a>
+                    </Placeholder>
+                    <Placeholder>
+                        <PlaceholderContent>
                             <div>
                                 <small class="placeholder">$0.00</small>
                                 <small class="placeholder ms-1">$0.00</small>
                             </div>
-                        </div>
-                        <div class="d-none d-lg-block text-center mt-1">
+                        </PlaceholderContent>
+                        <ChildContent>
+                            @RenderBalanceValue(item.Model.IncomeSummary, item.Model.ExpenseSummary, item.Model.ExpectedExpenseSummary)
+                        </ChildContent>
+                    </Placeholder>
+                </div>
+                <div class="d-none d-lg-block text-center mt-1">
+                    <Placeholder>
+                        <PlaceholderContent>
                             <small class="d-block placeholder">$0.00</small>
                             <small class="d-block placeholder">$0.00</small>
                             <div class="text-center mt-1">
-                                @monthName
+                                <span class="placeholder col-6"></span>
                             </div>
-                        </div>
-                    </div>
-                    <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                        <div class="bg-secondary" style="width: @(incomeHeight)%; height: 10px; opacity: .5;"></div>
-                        <div class="mt-1 d-flex">
-                            <div class="bg-secondary" style="width: @(expenseHeight)%; height: 10px; opacity: .5;"></div>
-                        </div>
-                    </div>
-                </div>
-            }
-        </div>
-    </LoadingContent>
-    <ChildContent>
-        @if (Models != null)
-        {
-            <div class="row no-gutters" style="min-height: calc(100vh - 402px)">
-                @foreach (var model in Models)
-                {
-                    var expenseSize = MaxAmount == 0 ? 0 : model.ExpenseSummary.Value / MaxAmount * 100;
-                    var expectedExpenseSize = MaxAmount == 0 ? 0 : (model.ExpectedExpenseSummary?.Value ?? 0) / MaxAmount * 100;
-                    var incomeSize = MaxAmount == 0 ? 0 : model.IncomeSummary.Value / MaxAmount * 100;
-
-                    <div class="col-12 col-lg-1 @(model > AppDateTime.Today ? "text-muted" : String.Empty)">
-                        <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
-                            <div class="w-50 bg-success" style="height: @incomeSize%"></div>
-                            <div class="w-50 h-100 d-flex flex-column justify-content-end">
-                                <div class="w-100 bg-danger" style="height: @expectedExpenseSize%; opacity: .5;"></div>
-                                <div class="w-100 bg-danger" style="height: @expenseSize%;"></div>
-                            </div>
-                        </div>
-                        <div class="p-1">
-                            <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                                <a href="@Navigator.UrlOverview(model)">
-                                    @model.ToMonthString()
+                        </PlaceholderContent>
+                        <ChildContent>
+                            @RenderBalanceValue(
+                                item.Model.IncomeSummary, 
+                                item.Model.ExpenseSummary, 
+                                item.Model.ExpectedExpenseSummary, 
+                                "d-none d-lg-block text-center mt-1", 
+                                "d-block"
+                            )
+                            <div class="text-center mt-1">
+                                <a href="@Navigator.UrlOverview(item.Model)">
+                                    <span class="d-none d-lg-inline">
+                                        @item.Model.ToMonthString()
+                                    </span>
+                                    <span class="d-inline d-lg-none">
+                                        @item.Model.Month.ToString("D2")
+                                    </span>
                                 </a>
-                                @RenderBalanceValue(model.IncomeSummary, model.ExpenseSummary, model.ExpectedExpenseSummary)
                             </div>
-                            <div class="d-none d-lg-block text-center mt-1">
-                                @RenderBalanceValue(
-                                    model.IncomeSummary, 
-                                    model.ExpenseSummary, 
-                                    model.ExpectedExpenseSummary, 
-                                    "d-none d-lg-block text-center mt-1", 
-                                    "d-block"
-                                )
-                                <div class="text-center mt-1">
-                                    <a href="@Navigator.UrlOverview(model)">
-                                        <span class="d-none d-lg-inline">
-                                            @model.ToMonthString()
-                                        </span>
-                                        <span class="d-inline d-lg-none">
-                                            @model.Month.ToString("D2")
-                                        </span>
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                            <div class="bg-success" style="width: @incomeSize%; height: 10px"></div>
-                            <div class="mt-1 d-flex">
-                                <div class="bg-danger" style="width: @expenseSize%; height: 10px"></div>
-                                <div class="bg-danger" style="width: @expectedExpenseSize%; height: 10px; opacity: .5;"></div>
-                            </div>
+                        </ChildContent>
+                    </Placeholder>
+                </div>
+            </div>
+            <Placeholder>
+                <PlaceholderContent>
+                    @{
+                        var placeholderMobileIncomeWidth = Random.Shared.Next(20, 90);
+                        var placeholderMobileExpenseWidth = Random.Shared.Next(20, 70);
+                    }
+                    <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
+                        <div class="bg-secondary" style="width: @(placeholderMobileIncomeWidth)%; height: 10px; opacity: .5;"></div>
+                        <div class="mt-1 d-flex">
+                            <div class="bg-secondary" style="width: @(placeholderMobileExpenseWidth)%; height: 10px; opacity: .5;"></div>
                         </div>
                     </div>
-                }
-            </div>
-        }
-    </ChildContent>
-</Loading>
+                </PlaceholderContent>
+                <ChildContent>
+                    <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
+                        <div class="bg-success" style="width: @incomeSize%; height: 10px"></div>
+                        <div class="mt-1 d-flex">
+                            <div class="bg-danger" style="width: @expenseSize%; height: 10px"></div>
+                            <div class="bg-danger" style="width: @expectedExpenseSize%; height: 10px; opacity: .5;"></div>
+                        </div>
+                    </div>
+                </ChildContent>
+            </Placeholder>
+        </div>
+    </AutoLoadListView>
+</div>

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor
@@ -69,9 +69,9 @@
         {
             @foreach (var model in Models)
             {
-                var expenseSize = MaxAmount == 0 ? 0 : model.ExpenseSummary.Value / MaxAmount * 100;
-                var expectedExpenseSize = MaxAmount == 0 ? 0 : (model.ExpectedExpenseSummary?.Value ?? 0) / MaxAmount * 100;
-                var incomeSize = MaxAmount == 0 ? 0 : model.IncomeSummary.Value / MaxAmount * 100;
+                var expenseSize = (MaxAmount == 0 ? 0 : model.ExpenseSummary.Value / MaxAmount * 100).ToString(System.Globalization.CultureInfo.InvariantCulture);
+                var expectedExpenseSize = (MaxAmount == 0 ? 0 : (model.ExpectedExpenseSummary?.Value ?? 0) / MaxAmount * 100).ToString(System.Globalization.CultureInfo.InvariantCulture);
+                var incomeSize = (MaxAmount == 0 ? 0 : model.IncomeSummary.Value / MaxAmount * 100).ToString(System.Globalization.CultureInfo.InvariantCulture);
 
                 <div class="col-12 col-lg-1 @(model > AppDateTime.Today ? "text-muted" : String.Empty)">
                     <Placeholder>

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
@@ -79,30 +79,39 @@ public partial class BalancesMonth(
             TotalIncomes = null;
             TotalExpenses = null;
             TotalExpectedExpenses = null;
-            Models = null;
+
+            InitModels(null);
 
             string defaultCurrency = await Queries.QueryAsync(new FindCurrencyDefault());
             var models = await Queries.QueryAsync(new ListMonthBalance(SelectedPeriod, includeExpectedExpenses: IncludeExpectedExpenses));
 
             MaxAmount = models.Count > 0 ? models.Max(m => Math.Max(m.IncomeSummary.Value, m.ExpenseSummary.Value + (m.ExpectedExpenseSummary?.Value ?? 0))) : 0;
-            Models = [];
-            TotalExpenses = Price.Zero(defaultCurrency);
-            TotalIncomes = Price.Zero(defaultCurrency);
-            TotalExpectedExpenses = Price.Zero(defaultCurrency);
-            for (int i = 0; i < 12; i++)
-            {
-                int month = i + 1;
-                var model = models.FirstOrDefault(m => m.Month == month);
-                if (model == null)
-                    model = new MonthBalanceModel(Year, month, Price.Zero(defaultCurrency), Price.Zero(defaultCurrency));
+            InitModels(defaultCurrency, models);
+        }
+    }
 
+    private void InitModels(string defaultCurrency, IReadOnlyList<MonthBalanceModel> source = null)
+    {
+        Models = [];
+        TotalExpenses = defaultCurrency != null ? Price.Zero(defaultCurrency) : null;
+        TotalIncomes = defaultCurrency != null ? Price.Zero(defaultCurrency) : null;
+        TotalExpectedExpenses = defaultCurrency != null ? Price.Zero(defaultCurrency) : null;
+        for (int i = 0; i < 12; i++)
+        {
+            int month = i + 1;
+            var model = source?.FirstOrDefault(m => m.Month == month);
+            if (model == null)
+                model = new MonthBalanceModel(Year, month, Price.Zero(defaultCurrency ?? "USD"), Price.Zero(defaultCurrency ?? "USD"));
+
+            if (defaultCurrency != null)
+            {
                 TotalExpenses += model.ExpenseSummary;
                 if (model.ExpectedExpenseSummary != null)
                     TotalExpectedExpenses += model.ExpectedExpenseSummary;
-
                 TotalIncomes += model.IncomeSummary;
-                Models.Add(model);
             }
+
+            Models.Add(model);
         }
     }
 

--- a/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/BalancesMonth.razor.cs
@@ -79,6 +79,7 @@ public partial class BalancesMonth(
             TotalIncomes = null;
             TotalExpenses = null;
             TotalExpectedExpenses = null;
+            Models = null;
 
             string defaultCurrency = await Queries.QueryAsync(new FindCurrencyDefault());
             var models = await Queries.QueryAsync(new ListMonthBalance(SelectedPeriod, includeExpectedExpenses: IncludeExpectedExpenses));


### PR DESCRIPTION
PR #676 added loading placeholders to the Balances page by duplicating the entire bar chart markup inside a `<Loading>` component's `<LoadingContent>` block. This created a maintenance burden -- any future layout change requires updating two copies of nearly identical markup.

## Approach

Replaced the separate `<LoadingContent>`/`<ChildContent>` structure with `PlaceholderContainer` and `Placeholder` components, following the same placeholder pattern used elsewhere in the app.

- Uses `PlaceholderContainer IsActive="@Loading.IsLoading"` wrapping a single `foreach` over `Models`
- Pre-populates `Models` with 12 zero-value items (correct months) before any awaits, so month names are always visible during loading
- Uses `Placeholder` components with `PlaceholderContent` to toggle between placeholder bars and real data bars within a single unified template
- Formats CSS percentage values with InvariantCulture to avoid broken styles in comma-separator cultures

The header total value placeholder (in the toolbar) remains unchanged since it is independent of the grid pattern.