### PR TITLE
Add placeholder loading UI for Trends pages

### DIFF
--- a/src/Money.Blazor.Host/Pages/Trends.razor
+++ b/src/Money.Blazor.Host/Pages/Trends.razor
@@ -3,28 +3,29 @@
 
 <Title Icon="chart-line" Main="Select a category" Sub="To open year trends" />
 
-@if (Categories == null)
-{
-    <Loading />
-}
-else
-{
-    <div class="row g-2">
-        @foreach (var category in Categories)
+<PlaceholderContainer IsActive="@(Categories == null)" Context="placeholderContext">
+    <div class="row g-2 @placeholderContext.CssClass">
+        @foreach (var category in (Categories ?? MockCategories))
         {
             <div class="col-4 col-md-2">
                 <a href="@Navigator.UrlTrends(category.Key)" class="btn w-100 h-100 @category.Color.SelectAccent("back-dark", "back-light")" style="background-color: @category.Color.ToHashCode();">
                     <div>
-                        <h2>@category.Icon</h2>
+                        <h2>
+                            <Placeholder WordMinLength="1" WordMaxLength="2">@category.Icon</Placeholder>
+                        </h2>
                     </div>
                     <div class="text-truncate">
-                        <strong>@category.Name</strong>
+                        <strong>
+                            <Placeholder WordMinLength="3" WordMaxLength="6">@category.Name</Placeholder>
+                        </strong>
                     </div>
                     <div class="text-truncate">
-                        <span>@EnsureHtmlWhitespace(category.Description)</span>
+                        <Placeholder WordMinLength="4" WordMaxLength="8">
+                            <span>@EnsureHtmlWhitespace(category.Description)</span>
+                        </Placeholder>
                     </div>
                 </a>
             </div>
         }
     </div>
-}
+</PlaceholderContainer>

--- a/src/Money.Blazor.Host/Pages/Trends.razor
+++ b/src/Money.Blazor.Host/Pages/Trends.razor
@@ -8,46 +8,23 @@
         @foreach (var category in (Categories ?? MockCategories))
         {
             <div class="col-4 col-md-2">
-                @if (placeholderContext.IsActive)
-                {
-                    <div class="btn w-100 h-100 @category.Color.SelectAccent("back-dark", "back-light")" style="background-color: @category.Color.ToHashCode();">
-                        <div>
-                            <h2>
-                                <Placeholder WordMinLength="1" WordMaxLength="2">@category.Icon</Placeholder>
-                            </h2>
-                        </div>
-                        <div class="text-truncate">
-                            <strong>
-                                <Placeholder WordMinLength="3" WordMaxLength="6">@category.Name</Placeholder>
-                            </strong>
-                        </div>
-                        <div class="text-truncate">
-                            <Placeholder WordMinLength="4" WordMaxLength="8">
-                                <span>@EnsureHtmlWhitespace(category.Description)</span>
-                            </Placeholder>
-                        </div>
+                <a href="@Navigator.UrlTrends(category.Key)" class="btn w-100 h-100 @(placeholderContext.IsActive ? "pe-none" : "") @category.Color.SelectAccent("back-dark", "back-light")" style="background-color: @category.Color.ToHashCode();" tabindex="@(placeholderContext.IsActive ? "-1" : null)">
+                    <div>
+                        <h2>
+                            <Placeholder WordMinLength="1" WordMaxLength="2">@category.Icon</Placeholder>
+                        </h2>
                     </div>
-                }
-                else
-                {
-                    <a href="@Navigator.UrlTrends(category.Key)" class="btn w-100 h-100 @category.Color.SelectAccent("back-dark", "back-light")" style="background-color: @category.Color.ToHashCode();">
-                        <div>
-                            <h2>
-                                <Placeholder WordMinLength="1" WordMaxLength="2">@category.Icon</Placeholder>
-                            </h2>
-                        </div>
-                        <div class="text-truncate">
-                            <strong>
-                                <Placeholder WordMinLength="3" WordMaxLength="6">@category.Name</Placeholder>
-                            </strong>
-                        </div>
-                        <div class="text-truncate">
-                            <Placeholder WordMinLength="4" WordMaxLength="8">
-                                <span>@EnsureHtmlWhitespace(category.Description)</span>
-                            </Placeholder>
-                        </div>
-                    </a>
-                }
+                    <div class="text-truncate">
+                        <strong>
+                            <Placeholder WordMinLength="3" WordMaxLength="6">@category.Name</Placeholder>
+                        </strong>
+                    </div>
+                    <div class="text-truncate">
+                        <Placeholder WordMinLength="4" WordMaxLength="8">
+                            <span>@EnsureHtmlWhitespace(category.Description)</span>
+                        </Placeholder>
+                    </div>
+                </a>
             </div>
         }
     </div>

--- a/src/Money.Blazor.Host/Pages/Trends.razor
+++ b/src/Money.Blazor.Host/Pages/Trends.razor
@@ -8,23 +8,46 @@
         @foreach (var category in (Categories ?? MockCategories))
         {
             <div class="col-4 col-md-2">
-                <a href="@Navigator.UrlTrends(category.Key)" class="btn w-100 h-100 @category.Color.SelectAccent("back-dark", "back-light")" style="background-color: @category.Color.ToHashCode();">
-                    <div>
-                        <h2>
-                            <Placeholder WordMinLength="1" WordMaxLength="2">@category.Icon</Placeholder>
-                        </h2>
+                @if (placeholderContext.IsActive)
+                {
+                    <div class="btn w-100 h-100 @category.Color.SelectAccent("back-dark", "back-light")" style="background-color: @category.Color.ToHashCode();">
+                        <div>
+                            <h2>
+                                <Placeholder WordMinLength="1" WordMaxLength="2">@category.Icon</Placeholder>
+                            </h2>
+                        </div>
+                        <div class="text-truncate">
+                            <strong>
+                                <Placeholder WordMinLength="3" WordMaxLength="6">@category.Name</Placeholder>
+                            </strong>
+                        </div>
+                        <div class="text-truncate">
+                            <Placeholder WordMinLength="4" WordMaxLength="8">
+                                <span>@EnsureHtmlWhitespace(category.Description)</span>
+                            </Placeholder>
+                        </div>
                     </div>
-                    <div class="text-truncate">
-                        <strong>
-                            <Placeholder WordMinLength="3" WordMaxLength="6">@category.Name</Placeholder>
-                        </strong>
-                    </div>
-                    <div class="text-truncate">
-                        <Placeholder WordMinLength="4" WordMaxLength="8">
-                            <span>@EnsureHtmlWhitespace(category.Description)</span>
-                        </Placeholder>
-                    </div>
-                </a>
+                }
+                else
+                {
+                    <a href="@Navigator.UrlTrends(category.Key)" class="btn w-100 h-100 @category.Color.SelectAccent("back-dark", "back-light")" style="background-color: @category.Color.ToHashCode();">
+                        <div>
+                            <h2>
+                                <Placeholder WordMinLength="1" WordMaxLength="2">@category.Icon</Placeholder>
+                            </h2>
+                        </div>
+                        <div class="text-truncate">
+                            <strong>
+                                <Placeholder WordMinLength="3" WordMaxLength="6">@category.Name</Placeholder>
+                            </strong>
+                        </div>
+                        <div class="text-truncate">
+                            <Placeholder WordMinLength="4" WordMaxLength="8">
+                                <span>@EnsureHtmlWhitespace(category.Description)</span>
+                            </Placeholder>
+                        </div>
+                    </a>
+                }
             </div>
         }
     </div>

--- a/src/Money.Blazor.Host/Pages/Trends.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Trends.razor.cs
@@ -2,6 +2,8 @@
 using Money.Models;
 using Money.Models.Queries;
 using Money.Services;
+using Neptuo;
+using Neptuo.Models.Keys;
 using Neptuo.Queries;
 using System;
 using System.Collections.Generic;
@@ -14,6 +16,10 @@ namespace Money.Pages;
 
 public partial class Trends(IQueryDispatcher Queries, Navigator Navigator)
 {
+    private static readonly List<CategoryModel> MockCategories = Enumerable.Range(0, 6)
+        .Select(_ => new CategoryModel(KeyFactory.Create(typeof(Category)), string.Empty, string.Empty, Color.FromArgb(255, 233, 236, 239), string.Empty))
+        .ToList();
+
     protected List<CategoryModel> Categories { get; set; }
 
     protected async override Task OnInitializedAsync()

--- a/src/Money.Blazor.Host/Pages/Trends.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Trends.razor.cs
@@ -17,7 +17,7 @@ namespace Money.Pages;
 public partial class Trends(IQueryDispatcher Queries, Navigator Navigator)
 {
     private static readonly List<CategoryModel> MockCategories = Enumerable.Range(0, 6)
-        .Select(_ => new CategoryModel(KeyFactory.Empty(typeof(Category)), string.Empty, string.Empty, Color.FromArgb(255, 233, 236, 239), string.Empty))
+        .Select(_ => new CategoryModel(KeyFactory.Create(typeof(Category)), string.Empty, string.Empty, Color.FromArgb(255, 233, 236, 239), string.Empty))
         .ToList();
 
     protected List<CategoryModel> Categories { get; set; }

--- a/src/Money.Blazor.Host/Pages/Trends.razor.cs
+++ b/src/Money.Blazor.Host/Pages/Trends.razor.cs
@@ -17,7 +17,7 @@ namespace Money.Pages;
 public partial class Trends(IQueryDispatcher Queries, Navigator Navigator)
 {
     private static readonly List<CategoryModel> MockCategories = Enumerable.Range(0, 6)
-        .Select(_ => new CategoryModel(KeyFactory.Create(typeof(Category)), string.Empty, string.Empty, Color.FromArgb(255, 233, 236, 239), string.Empty))
+        .Select(_ => new CategoryModel(KeyFactory.Empty(typeof(Category)), string.Empty, string.Empty, Color.FromArgb(255, 233, 236, 239), string.Empty))
         .ToList();
 
     protected List<CategoryModel> Categories { get; set; }

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -64,7 +64,7 @@
                             <div style="width: @size%; background: @CategoryColor.ToHashCode(); height: 10px;"></div>
                         </ChildContent>
                         <PlaceholderContent Context="_">
-                            <div class="placeholder" style="width: @size%; background: #e9ecef; height: 10px; min-height: 10px;"></div>
+                            <div class="placeholder d-block" style="width: @size%; background: #e9ecef; height: 10px; min-height: 10px;"></div>
                         </PlaceholderContent>
                     </Placeholder>
                 </div>

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -64,7 +64,7 @@
                             <div style="width: @size%; background: @CategoryColor.ToHashCode(); height: 10px;"></div>
                         </ChildContent>
                         <PlaceholderContent Context="_">
-                            <div class="placeholder" style="width: @size%; background: #e9ecef; height: 10px;"></div>
+                            <div class="placeholder" style="width: @size%; background: #e9ecef; height: 10px; min-height: 10px;"></div>
                         </PlaceholderContent>
                     </Placeholder>
                 </div>

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -14,9 +14,11 @@
 
 <PlaceholderContainer IsActive="@(Models == null)" Context="placeholderContext">
     <div class="row no-gutters @placeholderContext.CssClass" style="min-height: calc(100vh - 312px)">
-        @foreach (var model in (Models ?? MockModels))
+        @{ var items = Models ?? MockModels; }
+        @for (int i = 0; i < items.Count; i++)
         {
-            var size = Models != null ? (MaxAmount > 0 ? model.TotalAmount.Value / MaxAmount * 100 : 0) : Random.Shared.Next(20, 80);
+            var model = items[i];
+            var size = Models != null ? (MaxAmount > 0 ? model.TotalAmount.Value / MaxAmount * 100 : 0) : (decimal)PlaceholderBarSizes[i];
 
             <div class="col-12 col-lg-1 @(Models != null && model > AppDateTime.Today ? "text-muted" : String.Empty)">
                 <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
@@ -31,9 +33,16 @@
                 </div>
                 <div class="p-1">
                     <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                        <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                            @model.ToMonthString()
-                        </a>
+                        @if (placeholderContext.IsActive)
+                        {
+                            <span>@model.ToMonthString()</span>
+                        }
+                        else
+                        {
+                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                @model.ToMonthString()
+                            </a>
+                        }
                         <Placeholder WordMinLength="2" WordMaxLength="4">
                             <PriceView TagName="small" Value="model.TotalAmount" />
                         </Placeholder>
@@ -45,14 +54,26 @@
                             </Placeholder>
                         </div>
                         <div class="text-center mt-1">
-                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                            @if (placeholderContext.IsActive)
+                            {
                                 <span class="d-none d-lg-inline">
                                     @model.ToMonthString()
                                 </span>
                                 <span class="d-inline d-lg-none">
                                     @model.Month.ToString("D2")
                                 </span>
-                            </a>
+                            }
+                            else
+                            {
+                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                    <span class="d-none d-lg-inline">
+                                        @model.ToMonthString()
+                                    </span>
+                                    <span class="d-inline d-lg-none">
+                                        @model.Month.ToString("D2")
+                                    </span>
+                                </a>
+                            }
                         </div>
                     </div>
                 </div>

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -12,48 +12,65 @@
     </ButtonContent>
 </Title>
 
-@if (Models == null)
-{
-    <Loading />
-}
-else
-{
-    <div class="row no-gutters" style="min-height: calc(100vh - 312px)">
-        @foreach (var model in Models)
+<PlaceholderContainer IsActive="@(Models == null)" Context="placeholderContext">
+    <div class="row no-gutters @placeholderContext.CssClass" style="min-height: calc(100vh - 312px)">
+        @foreach (var model in (Models ?? MockModels))
         {
-            var size = model.TotalAmount.Value / MaxAmount * 100;
+            var size = Models != null ? (MaxAmount > 0 ? model.TotalAmount.Value / MaxAmount * 100 : 0) : Random.Shared.Next(20, 80);
 
-            <div class="col-12 col-lg-1 @(model > AppDateTime.Today ? "text-muted" : String.Empty)">
+            <div class="col-12 col-lg-1 @(Models != null && model > AppDateTime.Today ? "text-muted" : String.Empty)">
                 <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
-                    <div class="w-100" style="height: @size%; background: @CategoryColor.ToHashCode()"></div>
+                    <Placeholder>
+                        <ChildContent>
+                            <div class="w-100" style="height: @size%; background: @CategoryColor.ToHashCode()"></div>
+                        </ChildContent>
+                        <PlaceholderContent Context="_">
+                            <div class="w-100 placeholder" style="height: @size%; background: #e9ecef"></div>
+                        </PlaceholderContent>
+                    </Placeholder>
                 </div>
                 <div class="p-1">
                     <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                        <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                            @model.ToMonthString()
-                        </a>
-                        <PriceView TagName="small" Value="model.TotalAmount" />
+                        <Placeholder WordMinLength="3" WordMaxLength="5">
+                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                @model.ToMonthString()
+                            </a>
+                        </Placeholder>
+                        <Placeholder WordMinLength="2" WordMaxLength="4">
+                            <PriceView TagName="small" Value="model.TotalAmount" />
+                        </Placeholder>
                     </div>
                     <div class="d-none d-lg-block text-center mt-1">
                         <div class="d-none d-lg-block text-center mt-1">
-                            <PriceView TagName="small" Value="model.TotalAmount" />
+                            <Placeholder WordMinLength="2" WordMaxLength="4">
+                                <PriceView TagName="small" Value="model.TotalAmount" />
+                            </Placeholder>
                         </div>
                         <div class="text-center mt-1">
-                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                <span class="d-none d-lg-inline">
-                                    @model.ToMonthString()
-                                </span>
-                                <span class="d-inline d-lg-none">
-                                    @model.Month.ToString("D2")
-                                </span>
-                            </a>
+                            <Placeholder WordMinLength="3" WordMaxLength="5">
+                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                    <span class="d-none d-lg-inline">
+                                        @model.ToMonthString()
+                                    </span>
+                                    <span class="d-inline d-lg-none">
+                                        @model.Month.ToString("D2")
+                                    </span>
+                                </a>
+                            </Placeholder>
                         </div>
                     </div>
                 </div>
                 <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                    <div style="width: @size%; background: @CategoryColor.ToHashCode(); height: 10px;"></div>
+                    <Placeholder>
+                        <ChildContent>
+                            <div style="width: @size%; background: @CategoryColor.ToHashCode(); height: 10px;"></div>
+                        </ChildContent>
+                        <PlaceholderContent Context="_">
+                            <div class="placeholder" style="width: @size%; background: #e9ecef; height: 10px;"></div>
+                        </PlaceholderContent>
+                    </Placeholder>
                 </div>
             </div>
         }
     </div>
-}
+</PlaceholderContainer>

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -31,11 +31,9 @@
                 </div>
                 <div class="p-1">
                     <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                        <Placeholder WordMinLength="3" WordMaxLength="5">
-                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                @model.ToMonthString()
-                            </a>
-                        </Placeholder>
+                        <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                            @model.ToMonthString()
+                        </a>
                         <Placeholder WordMinLength="2" WordMaxLength="4">
                             <PriceView TagName="small" Value="model.TotalAmount" />
                         </Placeholder>
@@ -47,16 +45,14 @@
                             </Placeholder>
                         </div>
                         <div class="text-center mt-1">
-                            <Placeholder WordMinLength="3" WordMaxLength="5">
-                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                    <span class="d-none d-lg-inline">
-                                        @model.ToMonthString()
-                                    </span>
-                                    <span class="d-inline d-lg-none">
-                                        @model.Month.ToString("D2")
-                                    </span>
-                                </a>
-                            </Placeholder>
+                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                <span class="d-none d-lg-inline">
+                                    @model.ToMonthString()
+                                </span>
+                                <span class="d-inline d-lg-none">
+                                    @model.Month.ToString("D2")
+                                </span>
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor
@@ -33,16 +33,9 @@
                 </div>
                 <div class="p-1">
                     <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                        @if (placeholderContext.IsActive)
-                        {
-                            <span>@model.ToMonthString()</span>
-                        }
-                        else
-                        {
-                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                @model.ToMonthString()
-                            </a>
-                        }
+                        <a href="@Navigator.UrlOverview(model, CategoryKey)" class="@(placeholderContext.IsActive ? "pe-none text-body" : "")" tabindex="@(placeholderContext.IsActive ? "-1" : null)">
+                            @model.ToMonthString()
+                        </a>
                         <Placeholder WordMinLength="2" WordMaxLength="4">
                             <PriceView TagName="small" Value="model.TotalAmount" />
                         </Placeholder>
@@ -54,26 +47,14 @@
                             </Placeholder>
                         </div>
                         <div class="text-center mt-1">
-                            @if (placeholderContext.IsActive)
-                            {
+                            <a href="@Navigator.UrlOverview(model, CategoryKey)" class="@(placeholderContext.IsActive ? "pe-none text-body" : "")" tabindex="@(placeholderContext.IsActive ? "-1" : null)">
                                 <span class="d-none d-lg-inline">
                                     @model.ToMonthString()
                                 </span>
                                 <span class="d-inline d-lg-none">
                                     @model.Month.ToString("D2")
                                 </span>
-                            }
-                            else
-                            {
-                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                    <span class="d-none d-lg-inline">
-                                        @model.ToMonthString()
-                                    </span>
-                                    <span class="d-inline d-lg-none">
-                                        @model.Month.ToString("D2")
-                                    </span>
-                                </a>
-                            }
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor.cs
@@ -14,8 +14,10 @@ namespace Money.Pages;
 
 public partial class TrendsMonth(IQueryDispatcher Queries, Navigator Navigator)
 {
-    private static readonly List<MonthWithAmountModel> MockModels = Enumerable.Range(1, 12)
-        .Select(m => new MonthWithAmountModel(2020, m, Price.Zero("USD")))
+    private static readonly int[] PlaceholderBarSizes = [65, 40, 78, 25, 55, 90, 35, 70, 45, 82, 30, 60];
+
+    private List<MonthWithAmountModel> MockModels => Enumerable.Range(1, 12)
+        .Select(m => new MonthWithAmountModel(Year, m, Price.Zero("USD")))
         .ToList();
 
     [Parameter]

--- a/src/Money.Blazor.Host/Pages/TrendsMonth.razor.cs
+++ b/src/Money.Blazor.Host/Pages/TrendsMonth.razor.cs
@@ -14,6 +14,10 @@ namespace Money.Pages;
 
 public partial class TrendsMonth(IQueryDispatcher Queries, Navigator Navigator)
 {
+    private static readonly List<MonthWithAmountModel> MockModels = Enumerable.Range(1, 12)
+        .Select(m => new MonthWithAmountModel(2020, m, Price.Zero("USD")))
+        .ToList();
+
     [Parameter]
     public int Year { get; set; }
 

--- a/src/Money.Blazor.Host/Pages/TrendsYear.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsYear.razor
@@ -3,62 +3,79 @@
 
 <Title Icon="chart-line" Main="@($"{CategoryName} trends from {StartYear} to {StartYear.Year + ModelsCount - 1}")" Sub="See how the category expenses change in time" />
 
-@if (Models == null)
-{
-    <Loading />
-}
-else
-{
-    <div class="row no-gutters" style="min-height: calc(100vh - 332px)">
-        @foreach (var model in Models)
+<PlaceholderContainer IsActive="@(Models == null)" Context="placeholderContext">
+    <div class="row no-gutters @placeholderContext.CssClass" style="min-height: calc(100vh - 332px)">
+        @foreach (var model in (Models ?? MockModels))
         {
-            var size = MaxAmount == 0 ? 0 : model.TotalAmount.Value / MaxAmount * 100;
+            var size = Models != null ? (MaxAmount == 0 ? 0 : model.TotalAmount.Value / MaxAmount * 100) : Random.Shared.Next(20, 80);
 
-            <div class="col-12 col-lg-1 @(model > AppDateTime.Today ? "text-muted" : String.Empty)">
+            <div class="col-12 col-lg-1 @(Models != null && model > AppDateTime.Today ? "text-muted" : String.Empty)">
                 <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
-                    <div class="w-100" style="height: @size%; background: @CategoryColor.ToHashCode()"></div>
+                    <Placeholder>
+                        <ChildContent>
+                            <div class="w-100" style="height: @size%; background: @CategoryColor.ToHashCode()"></div>
+                        </ChildContent>
+                        <PlaceholderContent Context="_">
+                            <div class="w-100 placeholder" style="height: @size%; background: #e9ecef"></div>
+                        </PlaceholderContent>
+                    </Placeholder>
                 </div>
                 <div class="p-1">
                     <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                        <span>
-                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                @model
-                            </a>
-                            <a href="@Navigator.UrlTrends(model, CategoryKey)" class="ms-3">
-                                <Icon Identifier="chart-line" class="d-inline d-lg-none" />
-                                <span class="d-none d-lg-inline">
-                                    Months
-                                </span>
-                            </a>
-                        </span>
-                        <PriceView TagName="small" Value="model.TotalAmount" />
+                        <Placeholder WordMinCount="2" WordMaxCount="3" WordMinLength="3" WordMaxLength="5">
+                            <span>
+                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                    @model
+                                </a>
+                                <a href="@Navigator.UrlTrends(model, CategoryKey)" class="ms-3">
+                                    <Icon Identifier="chart-line" class="d-inline d-lg-none" />
+                                    <span class="d-none d-lg-inline">
+                                        Months
+                                    </span>
+                                </a>
+                            </span>
+                        </Placeholder>
+                        <Placeholder WordMinLength="2" WordMaxLength="4">
+                            <PriceView TagName="small" Value="model.TotalAmount" />
+                        </Placeholder>
                     </div>
                     <div class="d-none d-lg-block text-center mt-1">
                         <div class="d-none d-lg-block text-center mt-1">
-                            <PriceView TagName="small" Value="model.TotalAmount" />
+                            <Placeholder WordMinLength="2" WordMaxLength="4">
+                                <PriceView TagName="small" Value="model.TotalAmount" />
+                            </Placeholder>
                         </div>
                         <div class="text-center mt-1">
-                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                <span class="d-none d-lg-inline">
-                                    @model
-                                </span>
-                                <span class="d-inline d-lg-none">
-                                    @model.ToShortString()
-                                </span>
-                            </a>
-                            <a href="@Navigator.UrlTrends(model, CategoryKey)" class="btn btn-sm d-block btn-link">
-                                <Icon Identifier="chart-line" class="d-inline d-lg-none" />
-                                <span class="d-none d-lg-inline">
-                                    Months
-                                </span>
-                            </a>
+                            <Placeholder WordMinLength="3" WordMaxLength="4">
+                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                    <span class="d-none d-lg-inline">
+                                        @model
+                                    </span>
+                                    <span class="d-inline d-lg-none">
+                                        @model.ToShortString()
+                                    </span>
+                                </a>
+                                <a href="@Navigator.UrlTrends(model, CategoryKey)" class="btn btn-sm d-block btn-link">
+                                    <Icon Identifier="chart-line" class="d-inline d-lg-none" />
+                                    <span class="d-none d-lg-inline">
+                                        Months
+                                    </span>
+                                </a>
+                            </Placeholder>
                         </div>
                     </div>
                 </div>
                 <div class="d-block d-lg-none p-1 p-lg-3 mb-2">
-                    <div style="width: @size%; background: @CategoryColor.ToHashCode(); height: 10px;"></div>
+                    <Placeholder>
+                        <ChildContent>
+                            <div style="width: @size%; background: @CategoryColor.ToHashCode(); height: 10px;"></div>
+                        </ChildContent>
+                        <PlaceholderContent Context="_">
+                            <div class="placeholder" style="width: @size%; background: #e9ecef; height: 10px;"></div>
+                        </PlaceholderContent>
+                    </Placeholder>
                 </div>
             </div>
         }
     </div>
-}
+</PlaceholderContainer>

--- a/src/Money.Blazor.Host/Pages/TrendsYear.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsYear.razor
@@ -75,7 +75,7 @@
                             <div style="width: @size%; background: @CategoryColor.ToHashCode(); height: 10px;"></div>
                         </ChildContent>
                         <PlaceholderContent Context="_">
-                            <div class="placeholder" style="width: @size%; background: #e9ecef; height: 10px; min-height: 10px;"></div>
+                            <div class="placeholder d-block" style="width: @size%; background: #e9ecef; height: 10px; min-height: 10px;"></div>
                         </PlaceholderContent>
                     </Placeholder>
                 </div>

--- a/src/Money.Blazor.Host/Pages/TrendsYear.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsYear.razor
@@ -5,9 +5,11 @@
 
 <PlaceholderContainer IsActive="@(Models == null)" Context="placeholderContext">
     <div class="row no-gutters @placeholderContext.CssClass" style="min-height: calc(100vh - 332px)">
-        @foreach (var model in (Models ?? MockModels))
+        @{ var items = Models ?? MockModels; }
+        @for (int i = 0; i < items.Count; i++)
         {
-            var size = Models != null ? (MaxAmount == 0 ? 0 : model.TotalAmount.Value / MaxAmount * 100) : Random.Shared.Next(20, 80);
+            var model = items[i];
+            var size = Models != null ? (MaxAmount == 0 ? 0 : model.TotalAmount.Value / MaxAmount * 100) : (decimal)PlaceholderBarSizes[i];
 
             <div class="col-12 col-lg-1 @(Models != null && model > AppDateTime.Today ? "text-muted" : String.Empty)">
                 <div class="d-none d-lg-flex p-1 p-lg-3 h-100 w-100 vertical-bar">
@@ -23,15 +25,22 @@
                 <div class="p-1">
                     <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
                         <span>
-                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                @model
-                            </a>
-                            <a href="@Navigator.UrlTrends(model, CategoryKey)" class="ms-3">
-                                <Icon Identifier="chart-line" class="d-inline d-lg-none" />
-                                <span class="d-none d-lg-inline">
-                                    Months
-                                </span>
-                            </a>
+                            @if (placeholderContext.IsActive)
+                            {
+                                <span>@model</span>
+                            }
+                            else
+                            {
+                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                    @model
+                                </a>
+                                <a href="@Navigator.UrlTrends(model, CategoryKey)" class="ms-3">
+                                    <Icon Identifier="chart-line" class="d-inline d-lg-none" />
+                                    <span class="d-none d-lg-inline">
+                                        Months
+                                    </span>
+                                </a>
+                            }
                         </span>
                         <Placeholder WordMinLength="2" WordMaxLength="4">
                             <PriceView TagName="small" Value="model.TotalAmount" />
@@ -44,20 +53,32 @@
                             </Placeholder>
                         </div>
                         <div class="text-center mt-1">
-                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                            @if (placeholderContext.IsActive)
+                            {
                                 <span class="d-none d-lg-inline">
                                     @model
                                 </span>
                                 <span class="d-inline d-lg-none">
                                     @model.ToShortString()
                                 </span>
-                            </a>
-                            <a href="@Navigator.UrlTrends(model, CategoryKey)" class="btn btn-sm d-block btn-link">
-                                <Icon Identifier="chart-line" class="d-inline d-lg-none" />
-                                <span class="d-none d-lg-inline">
-                                    Months
-                                </span>
-                            </a>
+                            }
+                            else
+                            {
+                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                    <span class="d-none d-lg-inline">
+                                        @model
+                                    </span>
+                                    <span class="d-inline d-lg-none">
+                                        @model.ToShortString()
+                                    </span>
+                                </a>
+                                <a href="@Navigator.UrlTrends(model, CategoryKey)" class="btn btn-sm d-block btn-link">
+                                    <Icon Identifier="chart-line" class="d-inline d-lg-none" />
+                                    <span class="d-none d-lg-inline">
+                                        Months
+                                    </span>
+                                </a>
+                            }
                         </div>
                     </div>
                 </div>

--- a/src/Money.Blazor.Host/Pages/TrendsYear.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsYear.razor
@@ -25,15 +25,11 @@
                 <div class="p-1">
                     <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
                         <span>
-                            @if (placeholderContext.IsActive)
+                            <a href="@Navigator.UrlOverview(model, CategoryKey)" class="@(placeholderContext.IsActive ? "pe-none text-body" : "")" tabindex="@(placeholderContext.IsActive ? "-1" : null)">
+                                @model
+                            </a>
+                            @if (!placeholderContext.IsActive)
                             {
-                                <span>@model</span>
-                            }
-                            else
-                            {
-                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                    @model
-                                </a>
                                 <a href="@Navigator.UrlTrends(model, CategoryKey)" class="ms-3">
                                     <Icon Identifier="chart-line" class="d-inline d-lg-none" />
                                     <span class="d-none d-lg-inline">
@@ -53,25 +49,16 @@
                             </Placeholder>
                         </div>
                         <div class="text-center mt-1">
-                            @if (placeholderContext.IsActive)
-                            {
+                            <a href="@Navigator.UrlOverview(model, CategoryKey)" class="@(placeholderContext.IsActive ? "pe-none text-body" : "")" tabindex="@(placeholderContext.IsActive ? "-1" : null)">
                                 <span class="d-none d-lg-inline">
                                     @model
                                 </span>
                                 <span class="d-inline d-lg-none">
                                     @model.ToShortString()
                                 </span>
-                            }
-                            else
+                            </a>
+                            @if (!placeholderContext.IsActive)
                             {
-                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                    <span class="d-none d-lg-inline">
-                                        @model
-                                    </span>
-                                    <span class="d-inline d-lg-none">
-                                        @model.ToShortString()
-                                    </span>
-                                </a>
                                 <a href="@Navigator.UrlTrends(model, CategoryKey)" class="btn btn-sm d-block btn-link">
                                     <Icon Identifier="chart-line" class="d-inline d-lg-none" />
                                     <span class="d-none d-lg-inline">

--- a/src/Money.Blazor.Host/Pages/TrendsYear.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsYear.razor
@@ -75,7 +75,7 @@
                             <div style="width: @size%; background: @CategoryColor.ToHashCode(); height: 10px;"></div>
                         </ChildContent>
                         <PlaceholderContent Context="_">
-                            <div class="placeholder" style="width: @size%; background: #e9ecef; height: 10px;"></div>
+                            <div class="placeholder" style="width: @size%; background: #e9ecef; height: 10px; min-height: 10px;"></div>
                         </PlaceholderContent>
                     </Placeholder>
                 </div>

--- a/src/Money.Blazor.Host/Pages/TrendsYear.razor
+++ b/src/Money.Blazor.Host/Pages/TrendsYear.razor
@@ -22,19 +22,17 @@
                 </div>
                 <div class="p-1">
                     <div class="d-flex justify-content-between align-items-center d-lg-none text-start">
-                        <Placeholder WordMinCount="2" WordMaxCount="3" WordMinLength="3" WordMaxLength="5">
-                            <span>
-                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                    @model
-                                </a>
-                                <a href="@Navigator.UrlTrends(model, CategoryKey)" class="ms-3">
-                                    <Icon Identifier="chart-line" class="d-inline d-lg-none" />
-                                    <span class="d-none d-lg-inline">
-                                        Months
-                                    </span>
-                                </a>
-                            </span>
-                        </Placeholder>
+                        <span>
+                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                @model
+                            </a>
+                            <a href="@Navigator.UrlTrends(model, CategoryKey)" class="ms-3">
+                                <Icon Identifier="chart-line" class="d-inline d-lg-none" />
+                                <span class="d-none d-lg-inline">
+                                    Months
+                                </span>
+                            </a>
+                        </span>
                         <Placeholder WordMinLength="2" WordMaxLength="4">
                             <PriceView TagName="small" Value="model.TotalAmount" />
                         </Placeholder>
@@ -46,22 +44,20 @@
                             </Placeholder>
                         </div>
                         <div class="text-center mt-1">
-                            <Placeholder WordMinLength="3" WordMaxLength="4">
-                                <a href="@Navigator.UrlOverview(model, CategoryKey)">
-                                    <span class="d-none d-lg-inline">
-                                        @model
-                                    </span>
-                                    <span class="d-inline d-lg-none">
-                                        @model.ToShortString()
-                                    </span>
-                                </a>
-                                <a href="@Navigator.UrlTrends(model, CategoryKey)" class="btn btn-sm d-block btn-link">
-                                    <Icon Identifier="chart-line" class="d-inline d-lg-none" />
-                                    <span class="d-none d-lg-inline">
-                                        Months
-                                    </span>
-                                </a>
-                            </Placeholder>
+                            <a href="@Navigator.UrlOverview(model, CategoryKey)">
+                                <span class="d-none d-lg-inline">
+                                    @model
+                                </span>
+                                <span class="d-inline d-lg-none">
+                                    @model.ToShortString()
+                                </span>
+                            </a>
+                            <a href="@Navigator.UrlTrends(model, CategoryKey)" class="btn btn-sm d-block btn-link">
+                                <Icon Identifier="chart-line" class="d-inline d-lg-none" />
+                                <span class="d-none d-lg-inline">
+                                    Months
+                                </span>
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/src/Money.Blazor.Host/Pages/TrendsYear.razor.cs
+++ b/src/Money.Blazor.Host/Pages/TrendsYear.razor.cs
@@ -16,6 +16,10 @@ public partial class TrendsYear(IQueryDispatcher Queries, Navigator Navigator)
 {
     public const int ModelsCount = 10;
 
+    private static readonly List<YearWithAmountModel> MockModels = Enumerable.Range(2015, ModelsCount)
+        .Select(y => new YearWithAmountModel(y, Price.Zero("USD")))
+        .ToList();
+
     [Parameter]
     public Guid CategoryGuid { get; set; }
 

--- a/src/Money.Blazor.Host/Pages/TrendsYear.razor.cs
+++ b/src/Money.Blazor.Host/Pages/TrendsYear.razor.cs
@@ -16,8 +16,10 @@ public partial class TrendsYear(IQueryDispatcher Queries, Navigator Navigator)
 {
     public const int ModelsCount = 10;
 
-    private static readonly List<YearWithAmountModel> MockModels = Enumerable.Range(2015, ModelsCount)
-        .Select(y => new YearWithAmountModel(y, Price.Zero("USD")))
+    private static readonly int[] PlaceholderBarSizes = [55, 70, 35, 82, 45, 60, 78, 30, 65, 50];
+
+    private List<YearWithAmountModel> MockModels => Enumerable.Range(0, ModelsCount)
+        .Select(i => new YearWithAmountModel(AppDateTime.Today.Year - 8 + i, Price.Zero("USD")))
         .ToList();
 
     [Parameter]


### PR DESCRIPTION
While data loads on the Trends pages, users currently see a generic spinner that gives no sense of the page layout. This replaces those spinners with skeleton placeholders that mirror the actual content shape, providing a smoother loading experience.

## Approach

Uses the same `PlaceholderContainer` + `<Placeholder>` pattern established by `AutoLoadListView` and `ExpenseCard`. A single template renders both loading and real states -- the `<Placeholder>` component switches between skeleton spans and actual content based on the cascading `PlaceholderContainer.IsActive` state.

- **Trends.razor**: Iterates over `MockCategories` (6 gray tiles) during loading, with icon/name/description wrapped in `<Placeholder>`
- **TrendsMonth.razor**: Iterates over `MockModels` (12 months) with `<PlaceholderContent>` rendering randomized bar heights
- **TrendsYear.razor**: Same approach with 10 year columns

Each code-behind file adds a static mock list (`MockCategories` / `MockModels`) so the template can render without null issues during the loading state.

Fixes: #581