### PR TITLE
Update release notes and bump version to 1.22.0

### DIFF
--- a/src/Money.Blazor.Host/Money.Blazor.Host.csproj
+++ b/src/Money.Blazor.Host/Money.Blazor.Host.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Money</RootNamespace>
     <PublishDomain>app.money.neptuo.com</PublishDomain>
-    <VersionPrefix>1.21.1.0</VersionPrefix>
+    <VersionPrefix>1.22.0.0</VersionPrefix>
     <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
 	  <WasmFingerprintAssets Condition="'$(Configuration)' == 'Debug'">false</WasmFingerprintAssets>

--- a/src/Money.Blazor.Host/wwwroot/release-notes.html
+++ b/src/Money.Blazor.Host/wwwroot/release-notes.html
@@ -1,11 +1,20 @@
-﻿<h3>Fixed bugs</h3>
+﻿<h3>Features</h3>
 <ul>
-    <li>Mobile bottom menu has 1px gap between bottom bar.</li>
+    <li>Open expense create dialog from a URL.</li>
+    <li>Consolidate category icon list: fix duplicate and add common icons.</li>
+</ul>
+
+<h3>Improvements</h3>
+<ul>
+    <li>Placeholders for data loading in Balances.</li>
+    <li>Placeholders for data loading in Trends.</li>
+    <li>Placeholders for data loading in IncomeOverview.</li>
+    <li>Placeholders for data loading in MonthlyChecklist.</li>
 </ul>
 
 <div class="row">
     <div class="col-12 col-md-auto">
-        <a target="_blank" href="https://github.com/maraf/Money/releases/blazor-v1.21.1" class="btn bg-light-subtle w-100">
+        <a target="_blank" href="https://github.com/maraf/Money/releases/blazor-v1.22.0" class="btn bg-light-subtle w-100">
             <span class="fab fa-github"></span>
             See details on GitHub
         </a>


### PR DESCRIPTION
Prepares the release notes and version bump for the `blazor-v1.22.0` milestone.

The milestone includes 6 closed issues covering two new features and UX improvements for data loading states:

**Features**
- Open expense create dialog from a URL (#681)
- Consolidate category icon list: fix duplicate and add common icons (#677)

**Improvements**
- Placeholders for data loading in Balances, Trends, IncomeOverview, and MonthlyChecklist (#580, #581, #582, #583)

**Changes**
- Updated `release-notes.html` with the new milestone entries grouped by category
- Bumped `VersionPrefix` in `Money.Blazor.Host.csproj` from `1.21.1.0` to `1.22.0.0`